### PR TITLE
Remove locking from SoundEmojiSynthesizer.

### DIFF
--- a/inc/SoundEmojiSynthesizer.h
+++ b/inc/SoundEmojiSynthesizer.h
@@ -109,7 +109,6 @@ namespace codal
         public:
 
         DataSink*               downStream;             // Our downstream component.
-        FiberLock               lock;                   // Ingress queue to handle concurrent playback requests.
         ManagedBuffer           buffer;                 // Current playout buffer.
         ManagedBuffer           effectBuffer;           // Current sound effect sequence being generated.
         ManagedBuffer           emptyBuffer;            // Zero length buffer.


### PR DESCRIPTION
Playing a new sound changes what's being played.
The sync play method on sound expressions still allows waiting after
playing.

One approach to #6.