### PR TITLE
Fixing Inaccurate notes produced on Micro:bit v2

### DIFF
--- a/inc/Mixer2.h
+++ b/inc/Mixer2.h
@@ -98,7 +98,7 @@ public:
      * @param sampleRange (quantization levels) the difference between the maximum and minimum sample level on the output channel
      * @param format The format the mixer will output (DATASTREAM_FORMAT_16BIT_UNSIGNED or DATASTREAM_FORMAT_16BIT_SIGNED)
      */
-    Mixer2(int sampleRate = CONFIG_MIXER_DEFAULT_SAMPLERATE, int sampleRange = CONFIG_MIXER_INTERNAL_RANGE, int format = DATASTREAM_FORMAT_16BIT_UNSIGNED);
+    Mixer2(float sampleRate = CONFIG_MIXER_DEFAULT_SAMPLERATE, int sampleRange = CONFIG_MIXER_INTERNAL_RANGE, int format = DATASTREAM_FORMAT_16BIT_UNSIGNED);
 
     /**
      * Destructor.
@@ -113,7 +113,7 @@ public:
      * @param sampleRate (samples per second) - if set to zero, defaults to the output sample rate of the Mixer
      * @param sampleRange (quantization levels) the difference between the maximum and minimum sample level on the input channel
      */
-    MixerChannel *addChannel(DataSource &stream, int sampleRate = 0, int sampleRange = CONFIG_MIXER_INTERNAL_RANGE);
+    MixerChannel *addChannel(DataSource &stream, float sampleRate = 0, int sampleRange = CONFIG_MIXER_INTERNAL_RANGE);
 
     /**
      * Provide the next available ManagedBuffer to our downstream caller, if available.
@@ -169,7 +169,7 @@ public:
      * @param sampleRate The new sample rate (samples per second) of the mixer output
      * @return DEVICE_OK on success.
      */
-    int setSampleRate(int sampleRate);
+    int setSampleRate(float sampleRate);
 
     /**
      * Determine the sample range used by this Synthesizer,

--- a/source/MicroBitAudio.cpp
+++ b/source/MicroBitAudio.cpp
@@ -63,9 +63,11 @@ int MicroBitAudio::enable()
 {
     if (pwm == NULL)
     {
+
         pwm = new NRF52PWM(NRF_PWM1, mixer, 44100);
         pwm->setDecoderMode(PWM_DECODER_LOAD_Common);
 
+        mixer.setSampleRate(44100);
         mixer.setSampleRange(pwm->getSampleRange());
         mixer.setOrMask(0x8000);
 

--- a/source/Mixer2.cpp
+++ b/source/Mixer2.cpp
@@ -37,7 +37,7 @@ using namespace codal;
  * @param sampleRange (quantization levels) the difference between the maximum and minimum sample level on the output channel
  * @param format The format the mixer will output (DATASTREAM_FORMAT_16BIT_UNSIGNED or DATASTREAM_FORMAT_16BIT_SIGNED)
  */
-Mixer2::Mixer2(int sampleRate, int sampleRange, int format)
+Mixer2::Mixer2(float sampleRate, int sampleRange, int format)
 {
     // Set valid defaults.
     this->channels = NULL;
@@ -85,7 +85,7 @@ void Mixer2::configureChannel(MixerChannel *c)
  * @param sampleRate (samples per second) - if set to zero, defaults to the output sample rate of the Mixer
  * @param sampleRange (quantization levels) the difference between the maximum and minimum sample level on the input channel
  */
-MixerChannel *Mixer2::addChannel(DataSource &stream, int sampleRate, int sampleRange)
+MixerChannel *Mixer2::addChannel(DataSource &stream, float sampleRate, int sampleRange)
 {
     MixerChannel *c = new MixerChannel();
     c->stream = &stream;
@@ -304,10 +304,10 @@ int Mixer2::setSampleRange(uint16_t sampleRange)
  * @param sampleRate The new sample rate (samples per second) of the mixer output
  * @return DEVICE_OK on success.
  */
-int Mixer2::setSampleRate(int sampleRate)
+int Mixer2::setSampleRate(float sampleRate)
 {
     this->outputRate = (float)sampleRate;
-
+    
     // Recompute the sub/super sampling constants for each channel.    
     for (MixerChannel *c = channels; c; c=c->next)
         c->skip = c->rate / outputRate;


### PR DESCRIPTION
Changed variable sampleRate to float to avoid rounding errors when generating frequencies so that tones played via the microbit v2 internal speaker are now more accurate to the target frequency, during testing only 0.1-0.4hz out, which could be due to innacuracy in the detection equipment.
Additionally, manually set the mixer2 sample rate to 44100 in the microbit audio enable function. Some experinentation could be done here to match the sample rate to the true output from the PWM and observe if this improves accuracy futher.

This pull request mirrors and relies on lancaster-university/codal-nrf52 repo of the same name