### PR TITLE
Can't use original text as might still be "Copied"

### DIFF
--- a/resources/logfs/dl.js
+++ b/resources/logfs/dl.js
@@ -22,10 +22,9 @@
       copy: function () {
         base.copy();
         let button = window.event.currentTarget;
-        let original = button.innerText;
         button.innerText = "Copied";
         setTimeout(function () {
-          button.innerText = original;
+          button.innerText = "Copy";
         }, 1_000);
       },
       load: function () {


### PR DESCRIPTION
If the 1s timeout hadn't passed then we'll be reinstating the wrong
text for subsequent events, easy to trigger with a double click.

No change to the C++ resource as this feature is in the online HTML
only.

See https://github.com/lancaster-university/codal-microbit-v2/issues/110#issuecomment-859475124