### PR TITLE
Fix MicroBitBLEManager support for MicroBitPowerManager::deepSleep 

### DIFF
--- a/inc/bluetooth/MicroBitBLEManager.h
+++ b/inc/bluetooth/MicroBitBLEManager.h
@@ -197,6 +197,12 @@ class MicroBitBLEManager : public CodalComponent
      * */
     void onDisconnect();
 
+    /**
+     * Determine if Bluetooth is connected
+     * @return true if connected 
+     */
+    bool getConnected();
+
 #if CONFIG_ENABLED(MICROBIT_BLE_EDDYSTONE_URL)
     /**
       * Set the content of Eddystone URL frames

--- a/model/MicroBit.cpp
+++ b/model/MicroBit.cpp
@@ -334,8 +334,8 @@ void MicroBit::schedulerIdle()
 {
     if ( power.waitingForDeepSleep())
     {
-#if CONFIG_ENABLED( MICROBIT_BLE)
-        if ( bleManager.isConnected())
+#if CONFIG_ENABLED(DEVICE_BLE) && CONFIG_ENABLED(MICROBIT_BLE_ENABLED)
+        if ( bleManager.getConnected())
         {
             power.cancelDeepSleep();
             target_wait_for_event();

--- a/source/bluetooth/MicroBitBLEManager.cpp
+++ b/source/bluetooth/MicroBitBLEManager.cpp
@@ -1087,22 +1087,21 @@ int MicroBitBLEManager::setSleep(bool doSleep)
     if (doSleep)
     {
         app_timer_pause();
-
         wasEnabled = 0;
-        wasEnabled |= !nrf_sdh_is_suspended()               ? 1  : 0;
-        wasEnabled |= NVIC_GetEnableIRQ(RTC1_IRQn)          ? 2  : 0;
-        wasEnabled |= NVIC_GetEnableIRQ(MWU_IRQn)           ? 4  : 0;
-        wasEnabled |= NVIC_GetEnableIRQ(SWI5_EGU5_IRQn)     ? 8  : 0;
-        wasEnabled |= NVIC_GetEnableIRQ(POWER_CLOCK_IRQn)   ? 16 : 0;
-        wasEnabled |= NVIC_GetEnableIRQ(RTC0_IRQn)          ? 32 : 0;
-        wasEnabled |= NRF_SUCCESS == MICROBIT_BLE_ECHK( sd_ble_gap_adv_stop( m_adv_handle)) ? 64 : 0;
+        if (!nrf_sdh_is_suspended())                wasEnabled |= 1;
+        if (NVIC_GetEnableIRQ(RTC1_IRQn))           wasEnabled |= 2;
+        if (NVIC_GetEnableIRQ(MWU_IRQn))            wasEnabled |= 4;
+        if (NVIC_GetEnableIRQ(SWI5_EGU5_IRQn))      wasEnabled |= 8;
+        if (NVIC_GetEnableIRQ(POWER_CLOCK_IRQn))    wasEnabled |= 16;
+        if (NVIC_GetEnableIRQ(RTC0_IRQn))           wasEnabled |= 32;
+        if (NRF_SUCCESS == MICROBIT_BLE_ECHK( sd_ble_gap_adv_stop( m_adv_handle))) wasEnabled |= 64;
 
-        if ( wasEnabled & 1)    nrf_sdh_suspend();
-        if ( wasEnabled & 2)    NVIC_DisableIRQ(RTC1_IRQn);
-        if ( wasEnabled & 4)    NVIC_DisableIRQ(MWU_IRQn);
-        if ( wasEnabled & 8)    NVIC_DisableIRQ(SWI5_EGU5_IRQn);
-        if ( wasEnabled & 16)   NVIC_DisableIRQ(POWER_CLOCK_IRQn);
-        if ( wasEnabled & 32)   NVIC_DisableIRQ(RTC0_IRQn);
+        if (wasEnabled & 1)    nrf_sdh_suspend();
+        if (wasEnabled & 2)    NVIC_DisableIRQ(RTC1_IRQn);
+        if (wasEnabled & 4)    NVIC_DisableIRQ(MWU_IRQn);
+        if (wasEnabled & 8)    NVIC_DisableIRQ(SWI5_EGU5_IRQn);
+        if (wasEnabled & 16)   NVIC_DisableIRQ(POWER_CLOCK_IRQn);
+        if (wasEnabled & 32)   NVIC_DisableIRQ(RTC0_IRQn);
     }
     else
     {

--- a/source/bluetooth/MicroBitBLEManager.cpp
+++ b/source/bluetooth/MicroBitBLEManager.cpp
@@ -690,7 +690,17 @@ void MicroBitBLEManager::onDisconnect()
 }
 
 
-    
+
+/**
+ * Determine if Bluetooth is connected
+ * @return true if connected 
+ */
+bool MicroBitBLEManager::getConnected()
+{
+    return ble_conn_state_peripheral_conn_count() > 0;
+}
+
+
 #if CONFIG_ENABLED(MICROBIT_BLE_EDDYSTONE_URL)
 /**
   * Set the content of Eddystone URL frames


### PR DESCRIPTION
This fixes:
- master branch stops on wake-up with panic 070 once paired
- power down should be blocked while BLE is connected
- advertising is restarted on wake-up

Test program compiled with microbit-v2-samples and this branch of codal-microbit-v2: [MICROBIT.zip](https://github.com/lancaster-university/codal-microbit-v2/files/7656634/MICROBIT.zip)

It's possible to connect with the iOS micro:bit app monitor and see accelerometer readings, with power down suspended while connected. The button code below (A=>sleep; B=>wake and stay awake for 20s) is redundant with the timer.

main.cpp
```
#include "MicroBit.h"


MicroBit uBit;


void onClickA(MicroBitEvent)
{
    uBit.power.deepSleep();
}


void onClickB(MicroBitEvent)
{
    uBit.power.powerDownDisable();
    uBit.display.image.setPixelValue( 4, 0, 255);
    uBit.sleep(10000);
    uBit.display.image.setPixelValue( 4, 0, 0);
    uBit.power.powerDownEnable();
}


void onTimer(MicroBitEvent e)
{
    uBit.sleep(100);
    uBit.power.deepSleepAsync();
}


void display()
{
    uBit.power.powerDownDisable();
    uBit.display.scroll("RESET",50);
    uBit.power.powerDownEnable();
    uBit.display.print("*");

    while (true)
    {
        uBit.display.image.setPixelValue( 0, 0, uBit.display.image.getPixelValue( 0, 0) ? 0 : 255);
        uBit.sleep(1000);
    }
}


int 
main()
{
    uBit.init();

    new MicroBitAccelerometerService( *uBit.ble, uBit.accelerometer);

    uint16_t        timer_id      = 60000;
    uint16_t        timer_value   = 1;
    CODAL_TIMESTAMP timer_period  = 1000; //ms
    uBit.messageBus.listen( timer_id, timer_value, onTimer);
    system_timer_event_every( timer_period, timer_id, timer_value, CODAL_TIMER_EVENT_FLAGS_WAKEUP);

    uBit.messageBus.listen(MICROBIT_ID_BUTTON_A, MICROBIT_BUTTON_EVT_CLICK, onClickA);
    uBit.messageBus.listen(MICROBIT_ID_BUTTON_B, MICROBIT_BUTTON_EVT_CLICK, onClickB);

    uBit.io.buttonB.setActiveLo();
    uBit.io.buttonB.wakeOnActive(1);

    create_fiber(display);

    uBit.power.deepSleepAsync();

    release_fiber();
}

```

codal.json
```
{
    "target": {
        "name": "codal-microbit-v2",
        "url": "https://github.com/lancaster-university/codal-microbit-v2",
        "branch": "master",
        "type": "git",
        "test_ignore": true,
        "dev": true
    } ,
    "config":{
        "SOFTDEVICE_PRESENT": 1,
        "DEVICE_BLE": 1,
        "MICROBIT_BLE_ENABLED" : 1,
        "MICROBIT_BLE_PAIRING_MODE": 1,
        "MICROBIT_BLE_DFU_SERVICE": 1,
        "MICROBIT_BLE_DEVICE_INFORMATION_SERVICE": 1,
        "MICROBIT_BLE_EVENT_SERVICE" : 1,
        "MICROBIT_BLE_PARTIAL_FLASHING" : 0,
        "MICROBIT_BLE_SECURITY_LEVEL": "SECURITY_MODE_ENCRYPTION_NO_MITM"
    }
}

```