### PR TITLE
Minor fix to read back the right amount of I2C data from the interface MCU.

### DIFF
--- a/source/MicroBitUSBFlashManager.cpp
+++ b/source/MicroBitUSBFlashManager.cpp
@@ -152,7 +152,7 @@ int MicroBitUSBFlashManager::setConfiguration(MicroBitUSBFlashConfig config, boo
 
     // Write out each of the parameters in turn.
     transact(fname, 12);
-    transact(fsize, 2);
+    transact(fsize, 5);
     transact(fvisible, 2);
 
     if (persist)


### PR DESCRIPTION
A bit inconsequential as the data read back is not being used, but the interface firmware is meant to send back the same number of bytes that was written to it.