### PR TITLE
Increase DAPLink I2C wait for data to be ready timeout.

### DIFF
--- a/inc/MicroBitPowerManager.h
+++ b/inc/MicroBitPowerManager.h
@@ -44,7 +44,7 @@ DEALINGS IN THE SOFTWARE.
 // General constants 
 //
 #define MICROBIT_UIPM_MAX_BUFFER_SIZE               8
-#define MICROBIT_UIPM_MAX_RETRIES                   5
+#define MICROBIT_UIPM_MAX_RETRIES                   10
 #define MICROBIT_USB_INTERFACE_IRQ_THRESHOLD        30
 
 //

--- a/source/MicroBitPowerManager.cpp
+++ b/source/MicroBitPowerManager.cpp
@@ -236,12 +236,13 @@ ManagedBuffer MicroBitPowerManager::awaitUIPMPacket()
     }
 
     // If we time out, return a generic write error to the caller
+    DMESG("UIPM: Await timeout");
     ManagedBuffer error(2);
     error[0] = MICROBIT_UIPM_COMMAND_ERROR_RESPONSE;
     error[1] = MICROBIT_UIPM_WRITE_FAIL;
     awaitingPacket(false);
 
-    return error;    
+    return error;
 }
 
 


### PR DESCRIPTION
The current values for the retries (5 loops => 5ms) is enough for normal operation. However, when MakeCode is WebUSB connected to the micro:bit it must be performing background operations in DAPLink that might delay how long it takes for data to be ready to be sent back to CODAL.

In the worse case scenarios testing with a lot of serial data + requesting ADC readings it has sometimes taken up to 8 retries for the combined interrupt signal to be activated by DAPLink to signal that the data ready. Increasing this value from 5 to 10 shouldn't have any other adverse consequences, other than blocking the fiber in awaitUIPMPacket() a bit longer.