### PR TITLE
Patch to the PowerManager to catch standby messages

### DIFF
--- a/model/MicroBit.cpp
+++ b/model/MicroBit.cpp
@@ -171,7 +171,10 @@ int MicroBit::init()
     // Determine if we have been reprogrammed. If so, follow configured policy on erasing any persistent user data.
     eraseUserStorage();
 
-    // Bring up fiber scheduler.
+    // Force at least one check for if we're being told to sleep by DAPLink.
+    power.idleCallback();
+
+    // Otherwise just bring up the fiber scheduler.
     scheduler_init(messageBus);
 
     for(int i = 0; i < DEVICE_COMPONENT_COUNT; i++)

--- a/source/MicroBitPowerManager.cpp
+++ b/source/MicroBitPowerManager.cpp
@@ -318,7 +318,8 @@ void MicroBitPowerManager::off()
  */
 void MicroBitPowerManager::idleCallback()
 {
-    static int activeCount = 0;
+    // Start at our trigger value, so that the first call actually checks for data (required for standby/sleep modes)
+    static int activeCount = MICROBIT_USB_INTERFACE_IRQ_THRESHOLD;
 
     // Do nothing if there is a transaction in progress.
     if (status & MICROBIT_USB_INTERFACE_AWAITING_RESPONSE || !io.irq1.isActive())


### PR DESCRIPTION
Forces the PowerManager to check once on boot for any pending DAPLink messages, as would be the case for a long-press of the reset button, then otherwise run as normal.

This _might_ be a fix for https://github.com/microbit-foundation/DAPLink-microbit/issues/131 but needs more testing