### PR TITLE
MicroBitUtilityService - to read MicroBitLog MYDATA via BLE

### DIFF
--- a/inc/MicroBitConfig.h
+++ b/inc/MicroBitConfig.h
@@ -246,6 +246,18 @@ extern uint32_t __data_end__;
 #define MICROBIT_BLE_DEVICE_INFORMATION_SERVICE 1
 #endif
 
+// Enable/Disable BLE Service in pairing mode: MicroBitUtilityService
+// Set '1' to enable.
+#ifndef MICROBIT_BLE_UTILITY_SERVICE_PAIRING
+#define MICROBIT_BLE_UTILITY_SERVICE_PAIRING 1
+#endif
+
+// Enable/Disable BLE Service in application mode: MicroBitUtilityService
+// Set '1' to enable.
+#ifndef MICROBIT_BLE_UTILITY_SERVICE
+#define MICROBIT_BLE_UTILITY_SERVICE 0
+#endif
+
 // Enable/Disable Nordic Firmware style BLE based UART implimentation.
 // The default codal implimentation reverses the TX/RX ids  
 // Set to '1' to enable

--- a/inc/MicroBitLog.h
+++ b/inc/MicroBitLog.h
@@ -182,6 +182,14 @@ namespace codal
         }
     };
 
+
+    enum class DataFormat
+    {
+        HTMLHeader = 0,   // The HTML header without the data
+        HTML = 1,         // The entire HTML file
+        CSV = 2           // CSV data
+    };
+
     /**
      * Class definition for MicroBitLog. A simple text only, append only, single file log file system.
      * Also contains a key/value pair abstraction to enable dynamic creation of CSV based logfiles.
@@ -326,6 +334,30 @@ namespace codal
          * @param s the string to inject.
          */
         int logString(ManagedString s);
+        
+        /**
+         * Get the length of the recorded data
+         * @param format the data format
+         *          DataFormat::HTMLHeader = 0,   - The HTML header without the data
+         *          DataFormat::HTML = 1,               - The entire HTML file
+         *          DataFormat::CSV = 2                   - CSV data
+         * @return the length of the recorded data
+         */
+        uint32_t getDataLength(DataFormat format);
+        
+        /**
+         * Read the recorded data
+         * @param data pointer to memory to store the data
+         * @param index  the index into the data
+         * @param len length of the data to fetch
+         * @param format the data format
+         *          DataFormat::HTMLHeader = 0,   - The HTML header without data
+         *          DataFormat::HTML = 1,               - The entire HTML file with data
+         *          DataFormat::CSV = 2                   - CSV data
+         * @param length expected complete length returned from getDataLength
+         * @return DEVICE_OK on success; DEVICE_INVALID_PARAMETER if data is not available for the request
+         */
+        int readData(void *data, uint32_t index, uint32_t len, DataFormat format, uint32_t length);
 
     private:
 
@@ -349,6 +381,21 @@ namespace codal
         int _logString(const char *s);
         int _logString(ManagedString s);
 
+        int _readData(uint8_t *data, uint32_t index, uint32_t len, DataFormat format, uint32_t length);
+        
+        /**
+         * Read the source data from local memory or interface flash
+         * @param data pointer reference to memory to store the data
+         * @param index  reference to the index into the data
+         * @param len reference to the length of the data to fetch
+         * @param srcIndex reference to the index where the source data should begin
+         * @param srcPtr pointer to  source data in local memory. NULL to use srcAddress
+         * @param srcAddress address of source data in interface flash. Ignored if srcPtr is not NULL.
+         * @param srcLen the length of the source data
+         * @return DEVICE_OK on success; DEVICE_INVALID_PARAMETER if data is not available for the request
+         * @note On success, the referenced pointers, indices and lengths are updated ready for the next call
+         */
+        int _readSource( uint8_t *&data, uint32_t &index, uint32_t &len, uint32_t &srcIndex, const void *srcPtr, uint32_t srcAddress, uint32_t srcLen);
 
         /**
          * Add the given heading to the list of headings in use. If the heading already exists,

--- a/inc/bluetooth/MicroBitUtilityService.h
+++ b/inc/bluetooth/MicroBitUtilityService.h
@@ -1,0 +1,207 @@
+/*
+The MIT License (MIT)
+
+This class has been written for the Microbit Educational Foundation.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef MICROBIT_UTILITY_SERVICE_H
+#define MICROBIT_UTILITY_SERVICE_H
+
+#include "MicroBitConfig.h"
+
+#if CONFIG_ENABLED(DEVICE_BLE)
+
+#include "MicroBitBLEManager.h"
+#include "MicroBitBLEService.h"
+#include "MicroBitMemoryMap.h"
+
+#include "MicroBitFlash.h"
+#include "MicroBitStorage.h"
+
+#include "MicroBitComponent.h"
+#include "MicroBitEvent.h"
+#include "EventModel.h"
+#include "MicroBitLog.h"
+
+/* Set this to enable an alternative implementation, which creates a fiber to process requests.
+ * The default simply uses an event to trigger processing, and if processRequest() blocks,
+ * a temporary fiber is created as necessary.
+ */
+#ifndef MicroBitUtilityService_FIBER
+#define MicroBitUtilityService_FIBER 0
+#endif
+
+
+class MicroBitUtilityWorkspace;
+
+
+/**
+ * Class declration for the custom MicroBit Utility Service.
+ * Provides simple BLE request/response
+ * See MicroBitUtilityTypes.h
+ */
+class MicroBitUtilityService : public MicroBitBLEService
+{
+    static MicroBitUtilityService *shared;
+    
+    public:
+    /**
+     * Return a pointer to the shared service
+     * @return a pointer to the service, or NULL if it has not been created
+     */
+    static MicroBitUtilityService *getShared()
+    {
+        return shared;
+    }
+
+    /**
+     * Return a pointer to the shared service, creating it if necessary
+     * @param _ble an instance of BLEDevice
+     * @param _messageBus An instance of a MessageBus to interface with.
+     * @param _storage A persistent storage manager to use to hold non-volatile state.
+     * @param _log a log storage manager to read stored data.
+     * @return a pointer to the service, or NULL if it has not been created
+     */
+    static MicroBitUtilityService *createShared( BLEDevice &_ble, EventModel &_messageBus, MicroBitStorage &_storage, MicroBitLog &_log);
+
+    public:
+    /**
+     * Constructor.
+     * @param _ble an instance of BLEDevice
+     * @param _messageBus An instance of a MessageBus to interface with.
+     * @param _storage A persistent storage manager to use to hold non-volatile state.
+     * @param _log a log storage manager to read stored data.
+     */
+    MicroBitUtilityService( BLEDevice &_ble, EventModel &_messageBus, MicroBitStorage &_storage, MicroBitLog &_log);
+
+    private:
+    /**
+     * Invoked when BLE connects.
+     * Start listening for events
+    */
+    void onConnect( const microbit_ble_evt_t *p_ble_evt);
+
+    /**
+     * Invoked when BLE disconnects.
+     * Stop listening for events
+    */
+    void onDisconnect( const microbit_ble_evt_t *p_ble_evt);
+
+    /**
+     * Callback. Invoked when any of our attributes are written via BLE.
+     * Record the  request, and trigger processing.
+     * Requests are not queued. If a request is actively being processed, ignore the new request, otherwise simply override the previous one.
+     */
+    void onDataWritten(const microbit_ble_evt_write_t *params);
+
+    /**
+     * Callback. Invoked when a registered event occurs.
+     */
+    void onEvent(MicroBitEvent e);
+
+    private:
+    // MessageBus we're using
+    EventModel          &messageBus;
+    MicroBitStorage     &storage;
+    MicroBitLog         &log;
+
+    uint8_t characteristicValue[ 20];
+
+    // Index for each charactersitic in arrays of handles and UUIDs
+    typedef enum mbbs_cIdx
+    {
+        mbbs_cIdxCTRL,
+        mbbs_cIdxCOUNT
+    } mbbs_cIdx;
+    
+    // UUIDs for our service and characteristics
+    static const uint16_t serviceUUID;
+    static const uint16_t charUUID[ mbbs_cIdxCOUNT];
+    
+    // Data for each characteristic when they are held by Soft Device.
+    MicroBitBLEChar      chars[ mbbs_cIdxCOUNT];
+
+    public:
+    int              characteristicCount()          { return mbbs_cIdxCOUNT; };
+    MicroBitBLEChar *characteristicPtr( int idx)    { return &chars[ idx]; };
+    
+    private:
+    
+    MicroBitUtilityWorkspace *workspace;
+    
+    /**
+     * Listen for or ignore  events for processing requests
+     * @param yes true to listen, otherwise ignore
+     */
+    void listen( bool yes);
+    
+    /**
+     * Send a reply packet
+     * @param data Data to send
+     * @param length Length if the data
+     * @return DEVICE_OK if sent
+     */
+    int sendReply( const void *data, uint16_t length);
+    
+    /**
+     * Process the current request. This may block.
+     * @return DEVICE_OK if finished
+     */
+    int processRequest();
+
+    /**
+     * Process request typeLogLength
+     * @return DEVICE_OK if finished
+     */
+    int processLogLength();
+
+    /**
+     * Process request typeLogRead
+     * @return DEVICE_OK if finished
+     */
+    int processLogRead();
+    
+#if MicroBitUtilityService_FIBER
+    volatile int8_t fiberActive;
+    volatile bool   fiberExists;
+
+    /**
+     * Keep the fiber running or create a new one
+     */
+    void ensureFiber();
+    
+    /**
+     * Callback invoked when the fiber exits
+     * @param param Pointer to the MicroBitUtilityService
+     */
+    static void fiberComplete( void *param);
+    
+    /**
+     * Fiber to process requests, which releases itself after a period of inactivity
+     * @param param Pointer to the MicroBitUtilityService
+     */
+    static void fiberEntry( void *param);
+#endif
+};
+
+
+#endif
+#endif

--- a/inc/bluetooth/MicroBitUtilityTypes.h
+++ b/inc/bluetooth/MicroBitUtilityTypes.h
@@ -1,0 +1,115 @@
+/*
+The MIT License (MIT)
+
+This header has been written for the Microbit Educational Foundation.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef MICROBIT_UTILITY_TYPES_H
+#define MICROBIT_UTILITY_TYPES_H
+
+#include <stdint.h>
+
+/* Define types for the MicroBitUtilityService
+ *
+ * request_t  - Request sent from client to service.
+ *              job   (1 byte)          - see below
+ *              type  (1 byte)          - specifies the request type
+ *              data  (up to 18 bytes)  - depends on request type
+ *
+ * reply_t    - Reply from service to client.
+ *              job   (1 byte)          - see below
+ *              data  (up to 19 bytes)  - depends on request type
+ *
+ * job        - Synchronize requests and replies.
+ *              Enables the client to ignore replies to a previous request, and detect missing reply packets.
+ *              Client cycles high nibble i.e. { 0x00, 0x10, 0x20, ..., 0xF0, 0x00, ...}
+ *              Service reply cycles low nibble, i.e client job + { 0x00, 0x01, 0x02, ..., 0x0E, 0x00, ... }
+ *              low nibble == 0x0F (jobLowERR) in a reply indicates error (data = 4 bytes signed integer error)
+ *
+ * Request types and data contents:
+ *
+ * type 1     - Log file length
+ * request      format    (1 byte)          - 0 = HTML header; 1 = HTML; 2 = CSV
+ * reply        length    (4 bytes)         - unsigned integer log data length
+ *
+ * type 2     - Log file data
+ * request      format    (1 byte)          - 0 = HTML header; 1 = HTML; 2 = CSV
+ *              reserved  (1 byte)          - set to zero
+ *              index     (4 bytes)         - unsigned integer index into file
+ *              batchlen  (4 bytes)         - unsigned size in bytes to return
+ *              length    (4 bytes)         - length of whole file, from request type 1 (Log file length)
+ * reply        data      (up to 19 bytes)  - 1 or more reply packets, to total batchlen bytes
+ *
+ */
+namespace MicroBitUtility
+{
+    typedef enum requestType_t
+    {
+        requestTypeNone,
+        requestTypeLogLength,           // reply data = 4 bytes log data length
+        requestTypeLogRead              // reply data = up to 19 bytes of log data
+    } requestType_t;
+
+    typedef struct request_t
+    {
+        uint8_t  job;                   // Client cycles high nibble i.e. { 0x00, 0x10, 0x20, ..., 0xF0, 0x00, ...}
+        uint8_t  type;                  // requestType_t
+        uint8_t  data[18];
+    } request_t;
+    
+    typedef struct reply_t
+    {
+        uint8_t  job;                   // Service cycles low nibble i.e client job + { 0x00, 0x01, 0x02, ..., 0x0E, 0x00, ... }
+                                        // low nibble == 0x0F (jobLowERR) indicates error and data = 4 bytes signed integer error
+        uint8_t  data[19];
+    } reply_t;
+    
+    typedef enum requestLogFormat
+    {
+        requestLogHTMLHeader = 0,
+        requestLogHTML = 1,
+        requestLogCSV = 2
+    } requestLogFormat;
+
+    typedef struct requestLog_t
+    {
+        uint8_t  job;
+        uint8_t  type;                  // requestType_t
+        uint8_t  format;                // requestLogFormat
+    } requestLog_t;
+
+    typedef struct requestLogRead_t
+    {
+        uint8_t  job;
+        uint8_t  type;                  // requestType_t
+        uint8_t  format;                // requestLogFormat
+        uint8_t  reserved;              // set to zero
+        uint32_t index;                 // index into data
+        uint32_t batchlen;              // size in bytes to return
+        uint32_t length;                // length of whole file, from requestTypeLogLength
+    } requestLogRead_t;
+    
+    const uint8_t jobLowMAX = 0x0E;
+    const uint8_t jobLowERR = 0x0F;     // reply data = 4 bytes signed integer error
+};
+
+
+#endif

--- a/inc/compat/MicroBitCompat.h
+++ b/inc/compat/MicroBitCompat.h
@@ -368,6 +368,7 @@ typedef codal::BitmapFont MicroBitFont;
 #define MICROBIT_ID_MBED_TICKER                                 43
 
 #define MICROBIT_ID_LOG                                         44
+#define MICROBIT_ID_UTILITY                                     45
 
 #define MICROBIT_MAXIMUM_HEAPS                                  DEVICE_MAXIMUM_HEAPS
 #define MICROBIT_NESTED_HEAP_SIZE                               0

--- a/model/MicroBit.cpp
+++ b/model/MicroBit.cpp
@@ -250,7 +250,12 @@ int MicroBit::init()
 
             // Start the BLE stack, if it isn't already running.
             bleManager.init( ManagedString( microbit_friendly_name()), getSerial(), messageBus, storage, true, version.board);
-            
+
+#if CONFIG_ENABLED(MICROBIT_BLE_UTILITY_SERVICE_PAIRING)
+            MICROBIT_DEBUG_DMESG( "UTILITY_SERVICE");
+            MicroBitUtilityService::createShared( *ble, messageBus, storage, log);
+#endif
+
             // Enter pairing mode, using the LED matrix for any necessary pairing operations
             bleManager.pairingMode(display, buttonA);
         }
@@ -260,6 +265,11 @@ int MicroBit::init()
 #if CONFIG_ENABLED(DEVICE_BLE) && CONFIG_ENABLED(MICROBIT_BLE_ENABLED)
     // Start the BLE stack, if it isn't already running.
     bleManager.init( ManagedString( microbit_friendly_name()), getSerial(), messageBus, storage, false, version.board);
+
+#if CONFIG_ENABLED(MICROBIT_BLE_UTILITY_SERVICE)
+    MICROBIT_DEBUG_DMESG( "UTILITY_SERVICE");
+    MicroBitUtilityService::createShared( *ble, messageBus, storage, log);
+#endif
 #endif
 
     // Deschedule for a little while, just to allow for any components that finialise initialisation

--- a/model/MicroBit.h
+++ b/model/MicroBit.h
@@ -84,6 +84,7 @@ DEALINGS IN THE SOFTWARE.
 #include "MicroBitTemperatureService.h"
 #include "MicroBitUARTService.h"
 #include "MicroBitPartialFlashingService.h"
+#include "MicroBitUtilityService.h"
 #endif
 
 #include "MicroBitStorage.h"

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -976,6 +976,156 @@ bool MicroBitLog::isFull()
 }
 
 /**
+ * Get the length of the recorded data
+ * @param format the data format
+ *          DataFormat::HTMLHeader = 0,   - The HTML header without the data
+ *          DataFormat::HTML = 1,               - The entire HTML file
+ *          DataFormat::CSV = 2                   - CSV data
+ * @return the length of the recorded data
+ */
+uint32_t MicroBitLog::getDataLength(DataFormat format)
+{
+    uint32_t r = 0;
+    mutex.wait();
+    init();
+    uint32_t hdr = sizeof(header);
+    uint32_t mtr = sizeof(MicroBitLogMetaData);
+    uint32_t csv = dataEnd - dataStart;
+    switch (format)
+    {
+        case DataFormat::HTMLHeader:
+            r = hdr + mtr + 1;
+            break;
+        case DataFormat::HTML:
+            r = hdr + mtr + csv + 1;
+            break;
+        case DataFormat::CSV:
+            r = csv;
+            break;
+    }
+    mutex.notify();
+    return r;
+}
+
+/**
+ * Read the recorded data
+ * @param data pointer to memory to store the data
+ * @param index  the index into the data
+ * @param len length of the data to fetch
+ * @param format the data format
+ *          DataFormat::HTMLHeader = 0,   - The HTML header without data
+ *          DataFormat::HTML = 1,               - The entire HTML file with data
+ *          DataFormat::CSV = 2                   - CSV data
+ * @param length expected complete length returned from getDataLength
+ * @return DEVICE_OK on success; DEVICE_INVALID_PARAMETER if data is not available for the request
+ */
+int MicroBitLog::readData(void *data, uint32_t index, uint32_t len, DataFormat format, uint32_t length)
+{
+    int r;
+    mutex.wait();
+    r = _readData((uint8_t *) data, index, len, format, length);
+    mutex.notify();
+    return r;
+}
+
+int MicroBitLog::_readData(uint8_t *data, uint32_t index, uint32_t len, DataFormat format, uint32_t length)
+{
+    int r = DEVICE_OK;
+    
+    init();
+    
+    uint32_t hdr = sizeof(header);
+    uint32_t mtr = sizeof(MicroBitLogMetaData);
+
+    // Check if there is less data than expected
+    uint32_t dataMax = dataEnd - dataStart;
+    uint32_t dataLen = dataMax;
+    switch (format)
+    {
+        case DataFormat::HTML:
+            dataLen = length - hdr - mtr - 1;
+            break;
+        case DataFormat::CSV:
+            dataLen = length;
+            break;
+        default:
+            break;
+    }
+    if ( dataLen > dataMax)
+        return DEVICE_INVALID_PARAMETER;
+
+    // Generate metadata without journal pages
+    // logEnd is reduced by the same amount as dataStart
+    // TODO Do we want the journal pages in the HTML?
+    MicroBitLogMetaData meta = metaData;
+    writeNum(meta.dataStart+2, hdr + mtr);
+    writeNum(meta.logEnd+2, logEnd - (dataStart - hdr - mtr));
+
+    uint8_t end = 0xFF;
+    
+    uint32_t pos = 0;
+                      
+    switch (format)
+    {
+        case DataFormat::HTMLHeader:
+            _readSource( data, index, len, pos, header, 0, hdr);
+            _readSource( data, index, len, pos, &meta,  0, mtr);
+            _readSource( data, index, len, pos, &end,   0, sizeof(end));
+            break;
+        case DataFormat::HTML:
+            _readSource( data, index, len, pos, header, 0, hdr);
+            _readSource( data, index, len, pos, &meta,  0, mtr);
+            r = _readSource( data, index, len, pos, NULL, dataStart, dataLen);
+            if (r == DEVICE_OK)
+              _readSource( data, index, len, pos, &end, 0, sizeof(end));
+            break;
+        case DataFormat::CSV:
+            r = _readSource( data, index, len, pos, NULL, dataStart, dataLen);
+            break;
+    }
+    return r;
+}
+
+/**
+ * Read the source data from local memory or interface flash
+ * @param data pointer reference to memory to store the data
+ * @param index  reference to the index into the data
+ * @param len reference to the length of the data to fetch
+ * @param srcIndex reference to the index where the source data should begin
+ * @param srcPtr pointer to  source data in local memory. NULL to use srcAddress
+ * @param srcAddress address of source data in interface flash. Ignored if srcPtr is not NULL.
+ * @param srcLen the length of the source data
+ * @return DEVICE_OK on success; DEVICE_INVALID_PARAMETER if data is not available for the request
+ * @note On success, the referenced pointers, indices and lengths are updated ready for the next call
+ */
+int MicroBitLog::_readSource( uint8_t *&data, uint32_t &index, uint32_t &len, uint32_t &srcIndex, const void *srcPtr, uint32_t srcAddress, uint32_t srcLen)
+{
+    int r = DEVICE_OK;
+    uint32_t next = srcIndex + srcLen;
+    uint32_t length = index < next ? next - index : 0;
+    if ( length > len)
+        length = len;
+
+    if ( length)
+    {
+        if ( srcPtr)
+            memcpy(data, (const uint8_t *) srcPtr + (index - srcIndex), length);
+        else
+            r = cache.read( srcAddress + (index - srcIndex), data, length);
+    }
+
+    if ( r == DEVICE_OK)
+    {
+        data    += length;
+        index   += length;
+        len     -= length;
+
+        srcIndex = next;
+    }
+    return r;
+}
+
+/**
  * Destructor.
  */
 MicroBitLog::~MicroBitLog()

--- a/source/bluetooth/MicroBitBLEChar.cpp
+++ b/source/bluetooth/MicroBitBLEChar.cpp
@@ -65,7 +65,7 @@ bool MicroBitBLEChar::notifyChrValue( microbit_gaphandle_t connection, const uin
     if ( connection == BLE_CONN_HANDLE_INVALID)
         return false;
     
-    MICROBIT_DEBUG_DMESGF( "MicroBitBLEChar::notifyChrValue %d", (int) handles.value);
+    MICROBIT_DEBUG_DMESG( "MicroBitBLEChar::notifyChrValue %d", (int) handles.value);
     
     bool set = false;
     
@@ -78,7 +78,7 @@ bool MicroBitBLEChar::notifyChrValue( microbit_gaphandle_t connection, const uin
         hvx_params.p_len  = &length;
         hvx_params.p_data = data;
         
-        MICROBIT_DEBUG_DMESGF( "calling sd_ble_gatts_hvx( %d, %x, %d, %d)",
+        MICROBIT_DEBUG_DMESG( "calling sd_ble_gatts_hvx( %d, %x, %d, %d)",
                (int) handles.value, (unsigned int) data, (int) *data, (int) length);
         
         if ( MICROBIT_BLE_ECHK( sd_ble_gatts_hvx( connection, &hvx_params)) == NRF_SUCCESS)
@@ -100,7 +100,7 @@ bool MicroBitBLEChar::indicateChrValue( microbit_gaphandle_t connection, const u
     if ( connection == BLE_CONN_HANDLE_INVALID)
         return false;
     
-    MICROBIT_DEBUG_DMESGF( "MicroBitBLEChar::indicateChrValue %d", (int) handles.value);
+    MICROBIT_DEBUG_DMESG( "MicroBitBLEChar::indicateChrValue %d", (int) handles.value);
     
     bool set = false;
     
@@ -113,7 +113,7 @@ bool MicroBitBLEChar::indicateChrValue( microbit_gaphandle_t connection, const u
         hvx_params.p_len  = &length;
         hvx_params.p_data = data;
         
-        MICROBIT_DEBUG_DMESGF( "calling sd_ble_gatts_hvx( %d, %x, %d, %d)",
+        MICROBIT_DEBUG_DMESG( "calling sd_ble_gatts_hvx( %d, %x, %d, %d)",
                (int) handles.value, (unsigned int) data, (int) *data, (int) length);
 
         if ( MICROBIT_BLE_ECHK( sd_ble_gatts_hvx( connection, &hvx_params)) == NRF_SUCCESS)
@@ -135,7 +135,7 @@ bool MicroBitBLEChar::writeChrValue( microbit_gaphandle_t connection, const uint
     if ( connection == BLE_CONN_HANDLE_INVALID)
         return false;
  
-    MICROBIT_DEBUG_DMESGF( "MicroBitBLEChar::writeChrValue %d", (int) handles.value);
+    MICROBIT_DEBUG_DMESG( "MicroBitBLEChar::writeChrValue %d", (int) handles.value);
     
     bool done = true;
     

--- a/source/bluetooth/MicroBitUtilityService.cpp
+++ b/source/bluetooth/MicroBitUtilityService.cpp
@@ -1,0 +1,467 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2016 British Broadcasting Corporation.
+This software is provided by Lancaster University by arrangement with the BBC.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+*/
+
+/**
+  * Class definition for the custom MicroBit Utility service.
+  */
+#include "MicroBitConfig.h"
+
+#if CONFIG_ENABLED(DEVICE_BLE)
+
+#include "MicroBit.h"
+#include "MicroBitUtilityService.h"
+#include "MicroBitUtilityTypes.h"
+
+using namespace codal;
+using namespace MicroBitUtility;
+
+#define MICROBIT_ID_UTILITY_PROCESS 0
+
+#define MicroBitUtilityService_SLEEP 10
+#define MicroBitUtilityService_TIMEOUT 10
+
+namespace MicroBitUtility
+{
+    typedef enum replyState_t
+    {
+        replyStateClear,
+        replyStateReady,                // reply has been prepared but not sent
+        replyStateError
+    } replyState_t;
+};
+
+
+//TODO How to choose service and characteristic IDs?
+const uint16_t MicroBitUtilityService::serviceUUID               = 0x0001;
+const uint16_t MicroBitUtilityService::charUUID[ mbbs_cIdxCOUNT] = { 0x0002 };
+
+
+MicroBitUtilityService *MicroBitUtilityService::shared = NULL;
+
+
+/**
+ * Class definition for the MicroBit Utility Service workspace.
+ * Provides simple BLE request/response
+ * See MicroBitUtilityTypes.h
+ */
+class MicroBitUtilityWorkspace
+{
+    public:
+
+    request_t request;
+    reply_t   reply;
+    uint8_t   replyState;
+    uint8_t   replyLength;
+    uint8_t   jobLow;
+    bool      lock;
+
+    /**
+     * Constructor.
+     */
+    MicroBitUtilityWorkspace()
+    {
+        init();
+        lock = false;
+    }
+
+    /**
+     * Initialise workspace
+     */
+    void init()
+    {
+        memset( &request, 0, sizeof( request));
+        memset( &reply, 0, sizeof( reply));
+        replyState = replyStateClear;
+        replyLength = 0;
+        jobLow = 0;
+    }
+
+    /**
+     * Prepare workspace to process new request
+     */
+    void setRequest( const void *data, int len)
+    {
+        init();
+        memcpy( &request, data, len);
+    }
+    
+    /**
+     * Prepare reply to send
+     */
+    void setReplyReady( uint32_t replyLen)
+    {
+        reply.job   = request.job + jobLow;
+        replyLength = replyLen;
+        replyState  = replyStateReady;
+    }
+
+    /**
+     * Set the reply data to a uint32_t value
+     */
+    void setReply( uint32_t value)
+    {
+        memcpy( reply.data, &value, sizeof(uint32_t));
+        setReplyReady( sizeof(uint32_t));
+    }
+    
+    /**
+     * Set the reply data to an error
+     */
+    void setReplyError( uint32_t error)
+    {
+        setReply( error);
+        replyState = replyStateError;
+        reply.job = request.job + jobLowERR;
+    }
+
+    /**
+     * When a non-error reply has been sent, cycle jobLow for next reply
+     */
+    void onReplySent( const void *data)
+    {
+        reply_t *reply = (reply_t *) data;
+        if ( ( reply->job & 0x0F) != jobLowERR)
+        {
+            jobLow++;
+            if ( jobLow > jobLowMAX)
+                jobLow = 0;
+        }
+    }
+};
+
+
+/**
+ * Return a pointer to the shared service, creating it if necessary
+ * @param _ble an instance of BLEDevice
+ * @param _messageBus An instance of a MessageBus to interface with.
+ * @param _storage A persistent storage manager to use to hold non-volatile state.
+ * @return a pointer to the service, or NULL if it has not been created
+ */
+MicroBitUtilityService *MicroBitUtilityService::createShared( BLEDevice &_ble, EventModel &_messageBus, MicroBitStorage &_storage, MicroBitLog &_log)
+{
+    if ( !shared)
+        shared = new MicroBitUtilityService( _ble, _messageBus, _storage, _log);
+    return shared;
+}
+
+/**
+ * Constructor.
+ * Create a representation of the Utility Service
+ * @param _ble The instance of a BLE device that we're running on.
+ * @param _messageBus An instance of a MessageBus to interface with.
+ * @param _storage A persistent storage manager to use to hold non-volatile state.
+ * @param _log An instance of a MicroBitLog to interface with.
+ */
+MicroBitUtilityService::MicroBitUtilityService( BLEDevice &_ble, EventModel &_messageBus, MicroBitStorage &_storage, MicroBitLog &_log) :
+    messageBus(_messageBus), storage(_storage), log(_log), workspace(NULL)
+#if MicroBitUtilityService_FIBER
+    , fiberActive(0), fiberExists(false)
+#endif
+{
+    // Initialise data
+    memclr( characteristicValue, sizeof( characteristicValue));
+
+    // Register the base UUID and create the service.
+    RegisterBaseUUID( bs_base_uuid);
+    CreateService( serviceUUID);
+
+    CreateCharacteristic( mbbs_cIdxCTRL, charUUID[ mbbs_cIdxCTRL],
+                         characteristicValue,
+                         0, sizeof(characteristicValue),
+                         microbit_propWRITE | microbit_propWRITE_WITHOUT | microbit_propNOTIFY);
+    
+    if ( getConnected())
+        listen(true);
+}
+
+
+/**
+ * Invoked when BLE connects.
+ * Start listening for events
+ */
+void MicroBitUtilityService::onConnect( const microbit_ble_evt_t *p_ble_evt)
+{
+    listen(true);
+}
+
+
+/**
+ * Invoked when BLE disconnects.
+ * Stop listening for events
+ */
+void MicroBitUtilityService::onDisconnect( const microbit_ble_evt_t *p_ble_evt)
+{
+    listen(false);
+#if MicroBitUtilityService_FIBER
+    fiberActive = 0;
+#endif
+}
+
+
+/**
+ * Callback. Invoked when any of our attributes are written via BLE.
+ * Record the  request, and trigger processing.
+ * Requests are not queued. If a request is actively being processed, ignore the new request, otherwise simply override the previous one.
+ */
+void MicroBitUtilityService::onDataWritten(const microbit_ble_evt_write_t *params)
+{
+    if ( params->handle == valueHandle( mbbs_cIdxCTRL) && params->len > 0 && params->len < sizeof(request_t))
+    {
+        if ( workspace)
+        {
+            if ( workspace->lock)
+                return;
+        }
+        else
+        {
+            workspace = new MicroBitUtilityWorkspace();
+            if ( !workspace)
+                return;
+        }
+        
+        workspace->setRequest( params->data, params->len);
+#if MicroBitUtilityService_FIBER
+        if ( fiberActive)
+            fiberActive = MicroBitUtilityService_TIMEOUT;
+        else
+            MicroBitEvent evt( MICROBIT_ID_UTILITY, MICROBIT_ID_UTILITY_PROCESS);
+#else
+        MicroBitEvent evt( MICROBIT_ID_UTILITY, MICROBIT_ID_UTILITY_PROCESS);
+#endif
+    }
+}
+
+
+/**
+ * Callback. Invoked when a registered event occurs.
+ */
+void MicroBitUtilityService::onEvent(MicroBitEvent e)
+{
+    switch (e.source)
+    {
+        case MICROBIT_ID_UTILITY:
+            switch(e.value)
+            {
+                case MICROBIT_ID_UTILITY_PROCESS:
+#if MicroBitUtilityService_FIBER
+                    ensureFiber();
+#else
+                    processRequest();
+#endif
+                    break;
+            }
+            break;
+    }
+}
+
+
+/**
+ * Listen for or ignore  events for processing requests
+ * @param yes true to listen, otherwise ignore
+ */
+void MicroBitUtilityService::listen( bool yes)
+{
+    if ( yes)
+        messageBus.listen( MICROBIT_ID_UTILITY, MICROBIT_EVT_ANY, this, &MicroBitUtilityService::onEvent);
+    else
+        messageBus.ignore( MICROBIT_ID_UTILITY, MICROBIT_EVT_ANY, this, &MicroBitUtilityService::onEvent);
+}
+
+
+/**
+ * Send a reply packet
+ * @param data Data to send
+ * @param length Length if the data
+ * @return DEVICE_OK if sent
+ */
+int MicroBitUtilityService::sendReply( const void *data, uint16_t length)
+{
+    bool ok = notifyChrValue( mbbs_cIdxCTRL, (const uint8_t *) data, length);
+    if ( !ok)
+        return DEVICE_BUSY;
+    workspace->onReplySent( data);
+    return DEVICE_OK;
+}
+
+
+/**
+ * Process the current request. This may block.
+ * @return DEVICE_OK if finished
+ */
+int MicroBitUtilityService::processRequest()
+{
+    int result = DEVICE_OK;
+    
+    if ( workspace && !workspace->lock && workspace->request.type != requestTypeNone)
+    {
+        // Block changes to the request while processing it
+        workspace->lock = true;
+        
+        switch ( workspace->request.type)
+        {
+            case requestTypeLogLength:
+                result = processLogLength();
+                break;
+            case requestTypeLogRead:
+                result = processLogRead();
+                break;
+            default:
+                break;
+        }
+        
+        // Check if finished processing the current request
+        if ( result == DEVICE_OK)
+            workspace->init();
+
+        workspace->lock = false;
+    }
+    
+#if MicroBitUtilityService_FIBER
+#else
+    if ( workspace && workspace->request.type != requestTypeNone)
+        MicroBitEvent evt( MICROBIT_ID_UTILITY, MICROBIT_ID_UTILITY_PROCESS);
+#endif
+    return result;
+}
+
+
+/**
+ * Process request typeLogLength
+ * @return DEVICE_OK if finished
+ */
+int MicroBitUtilityService::processLogLength()
+{
+    if ( workspace->replyState == replyStateClear)
+    {
+        requestLog_t *request = (requestLog_t *) &workspace->request;
+        uint32_t length = log.getDataLength( (DataFormat) request->format);
+        workspace->setReply( length);
+    }
+    return sendReply( &workspace->reply, offsetof(reply_t, data) + workspace->replyLength);
+}
+
+
+/**
+ * Process request typeLogRead
+ * @return DEVICE_OK if finished
+ */
+int MicroBitUtilityService::processLogRead()
+{
+    requestLogRead_t *request = (requestLogRead_t *) &workspace->request;
+    
+    while ( request->batchlen)
+    {
+        if ( workspace->replyState == replyStateClear)
+        {
+            int block = min( request->batchlen, sizeof( reply_t) - offsetof( reply_t, data));
+            int result = log.readData(workspace->reply.data, request->index, block, (DataFormat) request->format, request->length);
+            if ( result)
+                workspace->setReplyError( result);
+            else
+                workspace->setReplyReady( block);
+        }
+        
+        int r = sendReply( &workspace->reply, offsetof(reply_t, data) + workspace->replyLength);
+        if ( r != DEVICE_OK)
+        {
+            return r;
+        }
+        
+        if ( workspace->replyState == replyStateError)
+        {
+            return DEVICE_OK;
+        }
+        
+        workspace->replyState = replyStateClear;
+        request->index       += workspace->replyLength;
+        request->batchlen    -= workspace->replyLength;
+    }
+    
+    return DEVICE_OK;
+}
+
+
+#if MicroBitUtilityService_FIBER
+
+/**
+ * Keep the fiber running or create a new fiber
+ */
+void MicroBitUtilityService::ensureFiber()
+{
+    if ( fiberActive)
+    {
+        fiberActive = MicroBitUtilityService_TIMEOUT;
+    }
+    else
+    {
+        fiberActive = 0;
+        while ( fiberExists)
+            fiber_sleep(0);
+        fiberActive = MicroBitUtilityService_TIMEOUT;
+        if ( create_fiber( MicroBitUtilityService::fiberEntry, this, MicroBitUtilityService::fiberComplete))
+            fiberExists = true;
+    }
+}
+
+
+/**
+ * Callback invoked when the fiber exits
+ * @param param Pointer to the MicroBitUtilityService
+ */
+void MicroBitUtilityService::fiberComplete( void *param)
+{
+    MicroBitUtilityService *self = (MicroBitUtilityService *) param;
+    self->fiberExists = false;
+    release_fiber(param);
+}
+
+
+/**
+ * Fiber to process requests, which releases itself after a period of inactivity
+ * @param param Pointer to the MicroBitUtilityService
+ */
+void MicroBitUtilityService::fiberEntry( void *param)
+{
+    MicroBitUtilityService *self = (MicroBitUtilityService *) param;
+    while (self->fiberActive > 0)
+    {
+        int result = self->processRequest();
+
+        if ( self->fiberActive <= 0)
+            break;
+        else if ( result != DEVICE_OK)
+            self->fiberActive = MicroBitUtilityService_TIMEOUT;
+        if ( --self->fiberActive <= 0)
+            break;
+        
+        fiber_sleep(MicroBitUtilityService_SLEEP);
+    }
+    self->fiberActive = 0;
+}
+
+#endif // MicroBitUtilityService_FIBER
+
+
+#endif


### PR DESCRIPTION
This depends on and includes PR https://github.com/lancaster-university/codal-microbit-v2/pull/177 "Add MicroBitLog::readData".

**TODO**: How should the service and characteristic UUIDs determined?
This currently uses the micro:bit base UUID plus 1 and 2.

MicroBitUtilityService.h/cpp - BLE service providing replies to simple client requests
MicroBitUtilityTypes.h - Details of the service requests that support reading MicroBitLog data
MicroBitCompat.h - Define MICROBIT_ID_UTILITY for service events
MicroBitConfig.h - Macros to control creation in pairing / application mode, default pairing mode only.
MicroBit.cpp - Create service according to config macros. To create in BLEManager::init would need to pass MicroBitLog.
MicroBitBLEChar.cpp - Changed DMESGF to DMESG.

Example hex [log-read-data-ble.hex.zip](https://github.com/lancaster-university/codal-microbit-v2/files/8257001/log-read-data-ble.hex.zip) is built from https://github.com/martinwork/microbit-v2-samples/tree/log-read-data-ble.
