### PR TITLE
Add support for including service uuids and manufacturer data in advertising data

### DIFF
--- a/inc/MicroBitBLEService.h
+++ b/inc/MicroBitBLEService.h
@@ -60,6 +60,7 @@ class MicroBitBLEService
 
     ~MicroBitBLEService();
 
+    ble_uuid_t getServiceUUID();
 
     protected:
     
@@ -137,6 +138,7 @@ class MicroBitBLEService
 
     uint8_t                     bs_uuid_type;
     microbit_servicehandle_t    bs_service_handle;
+    ble_uuid_t                  bs_service_uuid;
 
     static const uint8_t        bs_base_uuid[16];
 };

--- a/inc/MicroBitConfig.h
+++ b/inc/MicroBitConfig.h
@@ -247,7 +247,7 @@ extern uint32_t __data_end__;
 #endif
 
 // Enable/Disable Nordic Firmware style BLE based UART implimentation.
-// The default codal implimentation reverses the TX/RX ids  
+// The default codal implementation reverses the TX/RX ids  
 // Set to '1' to enable
 #ifndef MICROBIT_BLE_NORDIC_STYLE_UART
 #define MICROBIT_BLE_NORDIC_STYLE_UART 0
@@ -260,6 +260,10 @@ extern uint32_t __data_end__;
 //
 #ifndef MICROBIT_DAL_VERSION
 #define MICROBIT_DAL_VERSION                    "unknown"
+#endif
+
+#ifndef MICROBIT_SW_VERSION
+#define MICROBIT_SW_VERSION                     "unknown"
 #endif
 
 #endif

--- a/inc/bluetooth/MicroBitBLEManager.h
+++ b/inc/bluetooth/MicroBitBLEManager.h
@@ -160,6 +160,19 @@ class MicroBitBLEManager : public CodalComponent
     void advertise();
 
     /**
+     * When called, the micro:bit will begin advertising the supplied service's complete UUID.
+     *
+     * @param serviceUUIDs Pointer to an array of service UUID structures to insert into the advertising data.
+     * @param service_count Count of service UUID structures to insert into the advertising data.
+     * @param service_list_complete Flag to indicate whether the service UUID array contains all available services.
+     * @param manufacturer_id Manufacturer ID to insert into Manfacturer Data value in the advertising data.
+     * @param manufacturer_data Array of Manfacturer Data bytes to insert into the advertising data.
+     * @param manufacturer_data_size Size of Manfacturer Data array.
+     */
+    void advertise(ble_uuid_t *serviceUUIDs, uint16_t service_count = 1, bool service_list_complete = true,
+          uint16_t manufacturer_id = 0, uint8_t *manufacturer_data = nullptr, uint16_t manufacturer_data_size = 0);
+
+    /**
      * Determines the number of devices currently bonded with this micro:bit.
      * @return The number of active bonds.
      */

--- a/source/bluetooth/MicroBitBLEService.cpp
+++ b/source/bluetooth/MicroBitBLEService.cpp
@@ -53,6 +53,8 @@ MicroBitBLEService::MicroBitBLEService() :
     bs_uuid_type(0),
     bs_service_handle(0)
 {
+    bs_service_uuid.type = 0;
+    bs_service_uuid.uuid = 0;
     MicroBitBLEServices::getShared()->AddService( this);
 }
 
@@ -66,9 +68,10 @@ MicroBitBLEService::~MicroBitBLEService()
 void MicroBitBLEService::RegisterBaseUUID( const uint8_t *bytes16UUID)
 {
     ble_uuid128_t uuid128;
-    for ( int i = 0; i < 16; i++)
+    for ( int i = 0; i < 16; i++) {
         uuid128.uuid128[i] = bytes16UUID[ 15 - i];
-    
+    }
+
     MICROBIT_BLE_ECHK( sd_ble_uuid_vs_add( &uuid128, &bs_uuid_type));
     
     MICROBIT_DEBUG_DMESG( "MicroBitBLEService::RegisterBaseUUID bs_uuid_type = %d", (int) bs_uuid_type);
@@ -77,12 +80,10 @@ void MicroBitBLEService::RegisterBaseUUID( const uint8_t *bytes16UUID)
 
 void MicroBitBLEService::CreateService( uint16_t uuid)
 {
-    ble_uuid_t serviceUUID;
+    bs_service_uuid.uuid = uuid;
+    bs_service_uuid.type = bs_uuid_type;
     
-    serviceUUID.uuid = uuid;
-    serviceUUID.type = bs_uuid_type;
-
-    MICROBIT_BLE_ECHK( sd_ble_gatts_service_add( BLE_GATTS_SRVC_TYPE_PRIMARY, &serviceUUID, &bs_service_handle));
+    MICROBIT_BLE_ECHK( sd_ble_gatts_service_add( BLE_GATTS_SRVC_TYPE_PRIMARY, &bs_service_uuid, &bs_service_handle));
     
     MICROBIT_DEBUG_DMESG( "MicroBitBLEService::CreateService( %x) = %d", (unsigned int) uuid, (int) bs_service_handle);
 }
@@ -140,6 +141,10 @@ void MicroBitBLEService::CreateCharacteristic(
           (int) charHandles( idx)->sccd);
 }
 
+ble_uuid_t MicroBitBLEService::getServiceUUID()
+{
+    return bs_service_uuid;
+}
 
 microbit_gaphandle_t MicroBitBLEService::getConnectionHandle()
 {


### PR DESCRIPTION
Major: Add support for including service uuids and manufacturer data in advertising scan response data.
Minor: Populate HW Version and allow option to populate SW Version in DIS.