### PR TITLE
datalog htm: Fix unintuitive error msg when trying to plot with empty data.

### DIFF
--- a/resources/logfs/dl.js
+++ b/resources/logfs/dl.js
@@ -112,7 +112,7 @@ function UserGraphError(message) {
 
       graph: function () {
         function readData(table) {
-          if (table.rows.length === 0) {
+          if (!table || !table.rows || table.rows.length === 0) {
             throw new UserGraphError("No data to graph.");
           }
           const rows = table.rows;


### PR DESCRIPTION
Fixes issue https://github.com/lancaster-university/codal-microbit-v2/issues/143.

A simple one in the online JS, basically if the log is empty and the user clicks on "Visual Preview" it showed an `Unknown error` or `The visual preview requires two or more columns. Timestamps must be enabled.`

So, with this PR it will show the expected message `No data to graph.`.