### PR TITLE
Bug/flash configuration

### DIFF
--- a/inc/MicroBitUSBFlashManager.h
+++ b/inc/MicroBitUSBFlashManager.h
@@ -167,7 +167,7 @@ class MicroBitUSBFlashManager : public CodalComponent, public NVMController
         int eraseConfig();
 
         /**
-         * Reads data from the specified location in the USB file staorage area.
+         * Reads data from the specified location in the USB file storage area.
          * 
          * @param address the logical address of the memory to read.
          * @param length the number of 32-bit words to read.

--- a/source/MicroBitUSBFlashManager.cpp
+++ b/source/MicroBitUSBFlashManager.cpp
@@ -82,6 +82,10 @@ MicroBitUSBFlashConfig MicroBitUSBFlashManager::getConfiguration()
         memcpy(&s, &response[1], 4);
         config.fileSize = htonl(s);
 
+        // Sanity check that the filesize isnt longer than the possible block count
+        if( config.fileSize > MICROBIT_USB_FLASH_MAX_FLASH_STORAGE )
+            config.fileSize = MICROBIT_USB_FLASH_MAX_FLASH_STORAGE;
+
         // Load the visibility status
         response = transact(MICROBIT_USB_FLASH_VISIBILITY_CMD);
         config.visible = response[1] == 0 ? 0 : 1;
@@ -131,7 +135,7 @@ int MicroBitUSBFlashManager::setConfiguration(MicroBitUSBFlashConfig config, boo
         if (config.fileName.charAt(i) =='.')
             dots++;
         else if (!isValidChar(config.fileName.charAt(i)))
-            invalidChar = true;        
+            invalidChar = true;
     }
 
     // Blimey 8.3 is complex. :)


### PR DESCRIPTION
Minor patch to enforce the maximum flash file size for datalogging. This hard caps the file size.

Addresses issue #188 