### PR TITLE
Inserted a 1-buffer playback delay to the end of playback to sync external events

### DIFF
--- a/source/SoundEmojiSynthesizer.cpp
+++ b/source/SoundEmojiSynthesizer.cpp
@@ -207,6 +207,10 @@ ManagedBuffer SoundEmojiSynthesizer::pull()
                 done = true;
                 if (renderComplete || status & EMOJI_SYNTHESIZER_STATUS_STOPPING)
                 {
+                    // Wait for a hanful of milliseconds while we finish playing the last buffer we sent out ...
+                    fiber_sleep( buffer.length() / sampleRate );
+
+                    // ... THEN flip out status and fire the event
                     status &= ~EMOJI_SYNTHESIZER_STATUS_STOPPING;
                     Event(id, DEVICE_SOUND_EMOJI_SYNTHESIZER_EVT_DONE);
                     lock.notify();


### PR DESCRIPTION
Inserted a small delay into playback to account for the last buffer leaving the synth before emitting a complete event.

This should fix #189 whereby external events (like flipping a pin as playback ends) should now correctly sync up.