### PR TITLE
Bug/sound emoji timing

### DIFF
--- a/source/SoundEmojiSynthesizer.cpp
+++ b/source/SoundEmojiSynthesizer.cpp
@@ -207,6 +207,10 @@ ManagedBuffer SoundEmojiSynthesizer::pull()
                 done = true;
                 if (renderComplete || status & EMOJI_SYNTHESIZER_STATUS_STOPPING)
                 {
+                    // Wait for a hanful of milliseconds while we finish playing the last buffer we sent out ...
+                    fiber_sleep( buffer.length() / sampleRate );
+
+                    // ... THEN flip out status and fire the event
                     status &= ~EMOJI_SYNTHESIZER_STATUS_STOPPING;
                     Event(id, DEVICE_SOUND_EMOJI_SYNTHESIZER_EVT_DONE);
                     lock.notify();

--- a/source/SoundEmojiSynthesizer.cpp
+++ b/source/SoundEmojiSynthesizer.cpp
@@ -321,12 +321,17 @@ int SoundEmojiSynthesizer::getSampleRate()
 }
 
 /**
- * Change the sample rate used by this Synthesizer,
+ * Change the sample rate used by this Synthesizer.
+ * 
+ * This will prohibit updates if the requested sampleRate is less than 1, to safeguard processing later.
+ * 
  * @param frequency The new sample rate, in Hz.
- * @return DEVICE_OK on success.
+ * @return DEVICE_OK on success or ErrorCode::DEVICE_INVALID_STATUS if the sample rate is out of range.
  */
 int SoundEmojiSynthesizer::setSampleRate(int sampleRate)
 {
+    if( sampleRate < 1 )
+        return ErrorCode::DEVICE_INVALID_PARAMETER;
     this->sampleRate = sampleRate;
     return DEVICE_OK;
 }


### PR DESCRIPTION
Just a dead simple guard to prevent sample rates of less than 1 from breaking the synth.

This shouldn't happen unless someone starts hand-crafting buffers and channels, but just in case!