### PR TITLE
Added soft-failure modes for the accelerometer and compass to prevent panic-on-boot issues

### DIFF
--- a/inc/MicroBitError.h
+++ b/inc/MicroBitError.h
@@ -1,0 +1,38 @@
+/*
+The MIT License (MIT)
+Copyright (c) 2022 Lancaster University.
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef MicroBit_Error_H
+#define MicroBit_Error_H
+
+#include "ErrorNo.h"
+
+// Defined Micro:bit v2.xx specific error codes
+// For on-board peripherals these should be from PanicCode::DEVICE_PERIPHERAL_ERROR offset
+// to ensure we're in the correct range.
+// Note: the maximum offset for this range is +9, to avoid hitting the next block!
+enum MicroBitPanic {
+    // Accelerometer unable proceed (hardware i/o failure)
+    ACCELEROMETER_ERROR = PanicCode::DEVICE_PERIPHERAL_ERROR + 1, // Aka. Panic 51
+
+    // Compass unable to proceed (hardware i/o failure)
+    COMPASS_ERROR = PanicCode::DEVICE_PERIPHERAL_ERROR + 2        // Aka. Panic 52
+};
+
+#endif

--- a/source/MicroBitAccelerometer.cpp
+++ b/source/MicroBitAccelerometer.cpp
@@ -30,6 +30,7 @@ DEALINGS IN THE SOFTWARE.
 #include "MicroBitDevice.h"
 #include "MicroBitI2C.h"
 #include "MicroBitCompass.h"
+#include "MicroBitError.h"
 #include "LSM303Accelerometer.h"
 #include "LSM303Magnetometer.h"
 
@@ -72,12 +73,12 @@ Accelerometer& MicroBitAccelerometer::autoDetect(MicroBitI2C &i2c)
         MicroBitCompass::driver       = NULL;
 
         // Now, probe for the LSM303, and if it doesn't reply, panic
-        if (!LSM303Accelerometer::isDetected(i2c, 0x32))
-            microbit_panic( 50 ); // FixMe: This should be a constant from the PanicCode enum, but this is out of sync
-
-        MicroBitAccelerometer::driver = new LSM303Accelerometer( i2c, irq1, coordinateSpace, 0x32 );
-        MicroBitCompass::driver = new LSM303Magnetometer( i2c, irq1, coordinateSpace, 0x3C );
-        MicroBitCompass::driver->setAccelerometer( *MicroBitAccelerometer::driver );
+        if ( LSM303Accelerometer::isDetected(i2c, 0x32) )
+        {
+            MicroBitAccelerometer::driver = new LSM303Accelerometer( i2c, irq1, coordinateSpace, 0x32 );
+            MicroBitCompass::driver = new LSM303Magnetometer( i2c, irq1, coordinateSpace, 0x3C );
+            MicroBitCompass::driver->setAccelerometer( *MicroBitAccelerometer::driver );
+        }
 
         autoDetectCompleted = true;
     }
@@ -102,6 +103,9 @@ Accelerometer& MicroBitAccelerometer::autoDetect(MicroBitI2C &i2c)
   */
 int MicroBitAccelerometer::setPeriod(int period)
 {
+    if( driver == NULL )
+        target_panic( MicroBitPanic::ACCELEROMETER_ERROR );
+    
     return driver->setPeriod(period);
 }
 
@@ -112,6 +116,9 @@ int MicroBitAccelerometer::setPeriod(int period)
   */
 int MicroBitAccelerometer::getPeriod()
 {
+    if( driver == NULL )
+        target_panic( MicroBitPanic::ACCELEROMETER_ERROR );
+    
     return driver->getPeriod();
 }
 
@@ -132,6 +139,9 @@ int MicroBitAccelerometer::getPeriod()
   */
 int MicroBitAccelerometer::setRange(int range)
 {
+    if( driver == NULL )
+        target_panic( MicroBitPanic::ACCELEROMETER_ERROR );
+    
     return driver->setRange( range );
 }
 
@@ -142,6 +152,9 @@ int MicroBitAccelerometer::setRange(int range)
   */
 int MicroBitAccelerometer::getRange()
 {
+    if( driver == NULL )
+        target_panic( MicroBitPanic::ACCELEROMETER_ERROR );
+    
     return driver->getRange();
 }
 
@@ -158,6 +171,9 @@ int MicroBitAccelerometer::getRange()
  */
 int MicroBitAccelerometer::configure()
 {
+    if( driver == NULL )
+        target_panic( MicroBitPanic::ACCELEROMETER_ERROR );
+    
     return driver->configure();
 }
 
@@ -174,6 +190,9 @@ int MicroBitAccelerometer::configure()
  */
 int MicroBitAccelerometer::requestUpdate()
 {
+    if( driver == NULL )
+        target_panic( MicroBitPanic::ACCELEROMETER_ERROR );
+    
     return driver->requestUpdate();
 }
 
@@ -185,6 +204,9 @@ int MicroBitAccelerometer::requestUpdate()
  */
 Sample3D MicroBitAccelerometer::getSample(CoordinateSystem coordinateSystem)
 {
+    if( driver == NULL )
+        target_panic( MicroBitPanic::ACCELEROMETER_ERROR );
+    
     return driver->getSample( coordinateSystem );
 }
 
@@ -194,6 +216,9 @@ Sample3D MicroBitAccelerometer::getSample(CoordinateSystem coordinateSystem)
  */
 Sample3D MicroBitAccelerometer::getSample()
 {
+    if( driver == NULL )
+        target_panic( MicroBitPanic::ACCELEROMETER_ERROR );
+    
     return driver->getSample();
 }
 
@@ -205,6 +230,9 @@ Sample3D MicroBitAccelerometer::getSample()
  */
 int MicroBitAccelerometer::getX()
 {
+    if( driver == NULL )
+        target_panic( MicroBitPanic::ACCELEROMETER_ERROR );
+    
     return driver->getX();
 }
 
@@ -216,6 +244,9 @@ int MicroBitAccelerometer::getX()
  */
 int MicroBitAccelerometer::getY()
 {
+    if( driver == NULL )
+        target_panic( MicroBitPanic::ACCELEROMETER_ERROR );
+    
     return driver->getY();
 }
 
@@ -227,6 +258,9 @@ int MicroBitAccelerometer::getY()
  */
 int MicroBitAccelerometer::getZ()
 {
+    if( driver == NULL )
+        target_panic( MicroBitPanic::ACCELEROMETER_ERROR );
+    
     return driver->getZ();
 }
 
@@ -241,6 +275,9 @@ int MicroBitAccelerometer::getZ()
   */
 int MicroBitAccelerometer::getPitch()
 {
+    if( driver == NULL )
+        target_panic( MicroBitPanic::ACCELEROMETER_ERROR );
+    
     return driver->getPitch();
 }
 
@@ -255,6 +292,9 @@ int MicroBitAccelerometer::getPitch()
   */
 float MicroBitAccelerometer::getPitchRadians()
 {
+    if( driver == NULL )
+        target_panic( MicroBitPanic::ACCELEROMETER_ERROR );
+    
     return driver->getPitchRadians();
 }
 
@@ -269,6 +309,9 @@ float MicroBitAccelerometer::getPitchRadians()
   */
 int MicroBitAccelerometer::getRoll()
 {
+    if( driver == NULL )
+        target_panic( MicroBitPanic::ACCELEROMETER_ERROR );
+    
     return driver->getRoll();
 }
 
@@ -283,6 +326,9 @@ int MicroBitAccelerometer::getRoll()
   */
 float MicroBitAccelerometer::getRollRadians()
 {
+    if( driver == NULL )
+        target_panic( MicroBitPanic::ACCELEROMETER_ERROR );
+    
     return driver->getRollRadians();
 }
 
@@ -300,6 +346,9 @@ float MicroBitAccelerometer::getRollRadians()
   */
 uint16_t MicroBitAccelerometer::getGesture()
 {
+    if( driver == NULL )
+        target_panic( MicroBitPanic::ACCELEROMETER_ERROR );
+    
     return driver->getGesture();
 }
 

--- a/source/MicroBitCompass.cpp
+++ b/source/MicroBitCompass.cpp
@@ -28,6 +28,7 @@ DEALINGS IN THE SOFTWARE.
 #include "MicroBitCompat.h"
 #include "MicroBitFiber.h"
 #include "MicroBitDevice.h"
+#include "MicroBitError.h"
 #include "LSM303Magnetometer.h"
 
 Compass* MicroBitCompass::driver;
@@ -64,10 +65,6 @@ Compass& MicroBitCompass::autoDetect(MicroBitI2C &i2c)
     // We only have combined sensors, so rely on the accelerometer detection code to also detect the magnetomter.
     MicroBitAccelerometer::autoDetect(i2c);
 
-    // This should actually never happen (if the accelerometer fails, it already panics!), but its also checked here just in case
-    if( MicroBitCompass::driver == NULL )
-        target_panic( 51 ); // FixMe: This should be a constant from the PanicCode enum, but this is out of sync
-
     return *MicroBitCompass::driver;
 }
 
@@ -88,6 +85,9 @@ Compass& MicroBitCompass::autoDetect(MicroBitI2C &i2c)
  */
 int MicroBitCompass::heading()
 {
+    if( driver == NULL )
+        target_panic( MicroBitPanic::COMPASS_ERROR );
+
     return driver->heading();
 }
 
@@ -102,6 +102,9 @@ int MicroBitCompass::heading()
  */
 int MicroBitCompass::getFieldStrength()
 {
+    if( driver == NULL )
+        target_panic( MicroBitPanic::COMPASS_ERROR );
+    
     return driver->getFieldStrength();
 }
 
@@ -120,6 +123,9 @@ int MicroBitCompass::getFieldStrength()
  */
 int MicroBitCompass::calibrate()
 {
+    if( driver == NULL )
+        target_panic( MicroBitPanic::COMPASS_ERROR );
+    
     return driver->calibrate();
 }
 
@@ -135,6 +141,9 @@ int MicroBitCompass::calibrate()
  */
 void MicroBitCompass::setCalibration(CompassCalibration calibration)
 {
+    if( driver == NULL )
+        target_panic( MicroBitPanic::COMPASS_ERROR );
+    
     return driver->setCalibration( calibration );
 }
 
@@ -147,6 +156,9 @@ void MicroBitCompass::setCalibration(CompassCalibration calibration)
  */
 CompassCalibration MicroBitCompass::getCalibration()
 {
+    if( driver == NULL )
+        target_panic( MicroBitPanic::COMPASS_ERROR );
+    
     return driver->getCalibration();
 }
 
@@ -155,6 +167,9 @@ CompassCalibration MicroBitCompass::getCalibration()
  */
 int MicroBitCompass::isCalibrated()
 {
+    if( driver == NULL )
+        target_panic( MicroBitPanic::COMPASS_ERROR );
+    
     return driver->isCalibrated();
 }
 
@@ -163,6 +178,9 @@ int MicroBitCompass::isCalibrated()
  */
 int MicroBitCompass::isCalibrating()
 {
+    if( driver == NULL )
+        target_panic( MicroBitPanic::COMPASS_ERROR );
+    
     return driver->isCalibrating();
 }
 
@@ -171,6 +189,9 @@ int MicroBitCompass::isCalibrating()
  */
 void MicroBitCompass::clearCalibration()
 {
+    if( driver == NULL )
+        target_panic( MicroBitPanic::COMPASS_ERROR );
+    
     return driver->clearCalibration();
 }
 
@@ -184,6 +205,9 @@ void MicroBitCompass::clearCalibration()
  */
 int MicroBitCompass::configure()
 {
+    if( driver == NULL )
+        target_panic( MicroBitPanic::COMPASS_ERROR );
+    
     return driver->configure();
 }
 
@@ -195,6 +219,9 @@ int MicroBitCompass::configure()
  */
 void MicroBitCompass::setAccelerometer(MicroBitAccelerometer &accelerometer)
 {
+    if( driver == NULL )
+        target_panic( MicroBitPanic::COMPASS_ERROR );
+    
     return driver->setAccelerometer( accelerometer );
 }
 
@@ -211,6 +238,9 @@ void MicroBitCompass::setAccelerometer(MicroBitAccelerometer &accelerometer)
  */
 int MicroBitCompass::setPeriod(int period)
 {
+    if( driver == NULL )
+        target_panic( MicroBitPanic::COMPASS_ERROR );
+    
     return driver->setPeriod( period );
 }
 
@@ -237,6 +267,9 @@ int MicroBitCompass::getPeriod()
  */
 int MicroBitCompass::requestUpdate()
 {
+    if( driver == NULL )
+        target_panic( MicroBitPanic::COMPASS_ERROR );
+    
     return driver->requestUpdate();
 }
 
@@ -248,6 +281,9 @@ int MicroBitCompass::requestUpdate()
  */
 Sample3D MicroBitCompass::getSample(CoordinateSystem coordinateSystem)
 {
+    if( driver == NULL )
+        target_panic( MicroBitPanic::COMPASS_ERROR );
+    
     return driver->getSample( coordinateSystem );
 }
 
@@ -257,6 +293,9 @@ Sample3D MicroBitCompass::getSample(CoordinateSystem coordinateSystem)
  */
 Sample3D MicroBitCompass::getSample()
 {
+    if( driver == NULL )
+        target_panic( MicroBitPanic::COMPASS_ERROR );
+    
     return driver->getSample();
 }
 
@@ -268,6 +307,9 @@ Sample3D MicroBitCompass::getSample()
  */
 int MicroBitCompass::getX()
 {
+    if( driver == NULL )
+        target_panic( MicroBitPanic::COMPASS_ERROR );
+    
     return driver->getX();
 }
 
@@ -279,6 +321,9 @@ int MicroBitCompass::getX()
  */
 int MicroBitCompass::getY()
 {
+    if( driver == NULL )
+        target_panic( MicroBitPanic::COMPASS_ERROR );
+    
     return driver->getY();
 }
 
@@ -290,6 +335,9 @@ int MicroBitCompass::getY()
  */
 int MicroBitCompass::getZ()
 {
+    if( driver == NULL )
+        target_panic( MicroBitPanic::COMPASS_ERROR );
+    
     return driver->getZ();
 }
 


### PR DESCRIPTION
Added a new error class which uses PanicCode as a base for Micro:bit v2 specific errors, and implemented these in the Accel and Compass classes.

This addresses the case where a damaged accel/compass module would cause a board to panic on boot, effectively bricking the device even if the user code never touches the peripheral.

See also:
- https://github.com/lancaster-university/codal-core/pull/151
- https://github.com/lancaster-university/codal-microbit-v2/issues/213
- https://github.com/lancaster-university/codal-microbit-v2/issues/191