### PR TITLE
docstrings: Minor fix in documented define name.

### DIFF
--- a/inc/compat/MicroBitSerial.h
+++ b/inc/compat/MicroBitSerial.h
@@ -109,7 +109,7 @@ class MicroBitSerial : public NRF52Serial
       *
       * @param rx the new reception pin.
       *
-      * @return CODAL_SERIAL_IN_USE if another fiber is currently transmitting or receiving, otherwise DEVICE_OK.
+      * @return DEVICE_SERIAL_IN_USE if another fiber is currently transmitting or receiving, otherwise DEVICE_OK.
       */
     int redirect(PinName tx, PinName rx);
 
@@ -121,7 +121,7 @@ class MicroBitSerial : public NRF52Serial
       *
       * @param rx the new reception pin.
       *
-      * @return CODAL_SERIAL_IN_USE if another fiber is currently transmitting or receiving, otherwise DEVICE_OK.
+      * @return DEVICE_SERIAL_IN_USE if another fiber is currently transmitting or receiving, otherwise DEVICE_OK.
       */
     int redirect(PinNumber tx, PinNumber rx);
 

--- a/source/compat/MicroBitSerial.cpp
+++ b/source/compat/MicroBitSerial.cpp
@@ -109,7 +109,7 @@ MicroBitSerial::MicroBitSerial(PinNumber tx, PinNumber rx, uint8_t rxBufferSize,
   *
   * @param rx the new reception pin.
   *
-  * @return CODAL_SERIAL_IN_USE if another fiber is currently transmitting or receiving, otherwise DEVICE_OK.
+  * @return DEVICE_SERIAL_IN_USE if another fiber is currently transmitting or receiving, otherwise DEVICE_OK.
   */
 int MicroBitSerial::redirect(PinName tx, PinName rx) {
     static Pin *oldRx = NULL;
@@ -134,7 +134,7 @@ int MicroBitSerial::redirect(PinName tx, PinName rx) {
   *
   * @param rx the new reception pin.
   *
-  * @return CODAL_SERIAL_IN_USE if another fiber is currently transmitting or receiving, otherwise DEVICE_OK.
+  * @return DEVICE_SERIAL_IN_USE if another fiber is currently transmitting or receiving, otherwise DEVICE_OK.
   */
 int MicroBitSerial::redirect(PinNumber tx, PinNumber rx) {
     static Pin *oldRx = NULL;


### PR DESCRIPTION
The `CODAL_SERIAL_IN_USE` macro does not exist, the `codal-core` `Serial::redirect()` method returns `DEVICE_SERIAL_IN_USE` instead.

https://github.com/lancaster-university/codal-core/blob/a45ede432a646a0af86fbd89d9dd692689fb6fbd/source/driver-models/Serial.cpp#L842

Fixes https://github.com/lancaster-university/codal-microbit-v2/issues/238