### PR TITLE
Simplify the BLE - Device Info - Model Number to only indicate V2.

### DIFF
--- a/inc/bluetooth/MicroBitBLEManager.h
+++ b/inc/bluetooth/MicroBitBLEManager.h
@@ -123,7 +123,7 @@ class MicroBitBLEManager : public CodalComponent
       * bleManager.init(uBit.getName(), uBit.getSerial(), uBit.messageBus, true);
       * @endcode
       */
-    void init(ManagedString deviceName, ManagedString serialNumber, EventModel &messageBus, MicroBitStorage &keyValuestorage, bool enableBonding, uint16_t board = 0x9904);
+    void init(ManagedString deviceName, ManagedString serialNumber, EventModel &messageBus, MicroBitStorage &keyValuestorage, bool enableBonding);
     
     /**
      * Change the output power level of the transmitter to the given value.

--- a/model/MicroBit.cpp
+++ b/model/MicroBit.cpp
@@ -221,10 +221,6 @@ int MicroBit::init()
 
     power.readInterfaceRequest();
 
-#if CONFIG_ENABLED(DEVICE_BLE) && ( CONFIG_ENABLED(MICROBIT_BLE_PAIRING_MODE) || CONFIG_ENABLED(MICROBIT_BLE_ENABLED))
-    MicroBitVersion version = power.getVersion();
-#endif
-
 #if CONFIG_ENABLED(DEVICE_BLE) && CONFIG_ENABLED(MICROBIT_BLE_PAIRING_MODE)
     int i=0;
     // Test if we need to enter BLE pairing mode
@@ -255,7 +251,7 @@ int MicroBit::init()
             delete flashIncomplete;
 
             // Start the BLE stack, if it isn't already running.
-            bleManager.init( ManagedString( microbit_friendly_name()), getSerial(), messageBus, storage, true, version.board);
+            bleManager.init( ManagedString( microbit_friendly_name()), getSerial(), messageBus, storage, true);
             
             // Enter pairing mode, using the LED matrix for any necessary pairing operations
             bleManager.pairingMode(display, buttonA);
@@ -265,7 +261,7 @@ int MicroBit::init()
 
 #if CONFIG_ENABLED(DEVICE_BLE) && CONFIG_ENABLED(MICROBIT_BLE_ENABLED)
     // Start the BLE stack, if it isn't already running.
-    bleManager.init( ManagedString( microbit_friendly_name()), getSerial(), messageBus, storage, false, version.board);
+    bleManager.init( ManagedString( microbit_friendly_name()), getSerial(), messageBus, storage, false);
 #endif
 
     // Deschedule for a little while, just to allow for any components that finialise initialisation

--- a/source/MicroBitPowerManager.cpp
+++ b/source/MicroBitPowerManager.cpp
@@ -116,7 +116,7 @@ MicroBitVersion MicroBitPowerManager::getVersion()
         switch(version.board)
         {
             // V2.00 KL27
-            case 39172:
+            case 0x9904:
                 status |= MICROBIT_USB_INTERFACE_ALWAYS_NOP;
                 break;
 

--- a/source/bluetooth/MicroBitBLEManager.cpp
+++ b/source/bluetooth/MicroBitBLEManager.cpp
@@ -111,7 +111,6 @@ DEALINGS IN THE SOFTWARE.
 
 const char *MICROBIT_BLE_MANUFACTURER = NULL;
 const char *MICROBIT_BLE_MODEL = "BBC micro:bit";
-const char *MICROBIT_BLE_VERSION[2] = { "2.0", "2.X" };
 const char *MICROBIT_BLE_HARDWARE_VERSION = NULL;
 const char *MICROBIT_BLE_FIRMWARE_VERSION = MICROBIT_DAL_VERSION;
 const char *MICROBIT_BLE_SOFTWARE_VERSION = NULL;
@@ -229,7 +228,7 @@ MicroBitBLEManager *MicroBitBLEManager::getInstance()
   * bleManager.init(uBit.getName(), uBit.getSerial(), uBit.messageBus, true);
   * @endcode
   */
-void MicroBitBLEManager::init( ManagedString deviceName, ManagedString serialNumber, EventModel &messageBus, MicroBitStorage &keyValueStorage, bool enableBonding, uint16_t board)
+void MicroBitBLEManager::init( ManagedString deviceName, ManagedString serialNumber, EventModel &messageBus, MicroBitStorage &keyValueStorage, bool enableBonding)
 {
     if ( this->status & DEVICE_COMPONENT_RUNNING)
       return;
@@ -436,18 +435,10 @@ void MicroBitBLEManager::init( ManagedString deviceName, ManagedString serialNum
 
 #if CONFIG_ENABLED(MICROBIT_BLE_DEVICE_INFORMATION_SERVICE)
     MICROBIT_DEBUG_DMESG( "DEVICE_INFORMATION_SERVICE");
-    
-    int versionIdx = 0;
-    switch ( board)
-    {
-      case 0x9903:
-      case 0x9904:  break;
-      default:      versionIdx = 1; break;
-    }
 
-    ManagedString modelVersion( MICROBIT_BLE_VERSION[versionIdx]);
+    ManagedString modelVersion("V2");
     ManagedString disName( MICROBIT_BLE_MODEL);
-    disName = disName + " V" + modelVersion;
+    disName = disName + " " + modelVersion;
 
     ble_dis_init_t disi;
     memset( &disi, 0, sizeof(disi));


### PR DESCRIPTION
Before PR #114 the string was "BBC micro:bit V2.0", with that PR it was updated to indicate "BBC micro:bit V2.0" for board ID 0x9904 and "V2.X" to any unknown board ID (currently V2.2 boards would still appear as "V2.X").

There is no need for BLE apps or devices to distinguish between different V2 versions, just as we currently don't differentiate between V1.3 and V1.5.

Hardcoding this in CODAL to be "BBC micro:bit V2" also removes an I2C call to the interface chip on uBit.init(), which help us better support unofficial interface chip firmwares, like Segger's J-Link.

Fixes https://github.com/lancaster-university/codal-microbit-v2/issues/208

Related to https://github.com/lancaster-university/codal-microbit-v2/issues/137