### PR TITLE
CI: Add workflow to calculate build size diff before & after PR/commit.

### DIFF
--- a/.github/workflows/size-diff.yml
+++ b/.github/workflows/size-diff.yml
@@ -1,0 +1,129 @@
+name: Size diff
+
+on:
+  pull_request:
+    branches: '*'
+  # We can consider turning this off pushes if we wanted to reduce CI minutes
+  push:
+    branches: '*'
+
+jobs:
+  size-diff:
+    name: Run Bloaty
+    runs-on: ubuntu-latest
+    steps:
+      #########################
+      # Install the toolchain #
+      #########################
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.8'
+      - name: Setup arm-none-eabi-gcc
+        uses: carlosperate/arm-none-eabi-gcc-action@v1
+        with:
+          release: 10.3-2021.10
+      - name: Install Ninja & CMake via PyPI
+        run: python -m pip install ninja==1.11.1 cmake==3.25.0
+
+      #########################################
+      # Set up the CODAL project and build it #
+      #########################################
+      - name: Clone the microbit-v2-samples repository
+        uses: actions/checkout@v3
+        with:
+          repository: 'lancaster-university/microbit-v2-samples'
+      - name: Create libraries folder for the codal-microbit-v2 repo
+        run: mkdir libraries
+      # We need to use the checkout action (instead of build.py cloning the
+      # repository) to be able to get commit with the PR merge
+      - name: Clone the this repository in the libraries folder
+        uses: actions/checkout@v3
+        with:
+          path: libraries/codal-microbit-v2
+          fetch-depth: '0'
+      - name: Modify files to use BLE & this codal-microbit-v2 commit
+        shell: bash
+        run: |
+          rm codal.json
+          mv codal.ble.json codal.json
+          python -c "import pathlib; \
+                     f=pathlib.Path('codal.json'); \
+                     f.write_text(f.read_text().replace('lancaster-university/codal-microbit-v2', '${GITHUB_REPOSITORY}')); \
+                     f.write_text(f.read_text().replace('master', '${GITHUB_SHA}')); \
+                     f=pathlib.Path('source/main.cpp'); \
+                     f.write_text(f.read_text().replace('out_of_box_experience()', 'ble_test()'))"
+          cat codal.json
+      - name: Build using build.py
+        run: python build.py
+      - name: Save ELF file in diff directory
+        run: |
+          mkdir original-build
+          mv build/MICROBIT original-build/MICROBIT.elf
+      # 1st bloaty output (added to summary) shows memory consumption of top 30 components
+      - name: Run Bloaty McBloatface to view ELF file info
+        uses: carlosperate/bloaty-action@v0
+        with:
+          bloaty-args: original-build/MICROBIT.elf -d compileunits -n 30 -s vm
+          output-to-summary: true
+      # Manually clean the project
+      # If the codal-microbit-v2 target adds more libraries this step needs to include them as well
+      - name: Clean project
+        run: rm -rf build/ libraries/codal-core libraries/codal-microbit-nrf5sdk libraries/codal-nrf52
+
+      ####################################################################
+      # Set up codal-microbit-v2 to a parent/base commit and build again #
+      ####################################################################
+      - name: "PR: Get base commit SHA"
+        if: ${{ github.event.pull_request.base.sha }}
+        run: |
+          echo "${{ github.event.pull_request.base.sha }}"
+          echo "GIT_BASE_SHA=${{ github.event.pull_request.base.sha }}" >> $GITHUB_ENV
+          echo "# Bloaty comparison with PR base commit" >> $GITHUB_STEP_SUMMARY
+          echo "Base commit: ${{ github.event.pull_request.base.sha }}" >> $GITHUB_STEP_SUMMARY
+      - name: "Commit: Get parent commit SHA"
+        if: ${{ ! github.event.pull_request.base.sha }}
+        run: |
+          cd libraries/codal-microbit-v2
+          echo "$(git log --pretty=%P -n 1 HEAD^0)"
+          echo "GIT_BASE_SHA=$(git log --pretty=%P -n 1 HEAD^0)" >> $GITHUB_ENV
+          echo "# Bloaty comparison with parent commit" >> $GITHUB_STEP_SUMMARY
+          echo "Parent commit: $(git log --pretty=%P -n 1 HEAD^0)" >> $GITHUB_STEP_SUMMARY
+      - name: Modify codal.json files to use the base commit
+        shell: bash
+        run: |
+          python -c "import pathlib; \
+                     f=pathlib.Path('codal.json'); \
+                     f.write_text(f.read_text().replace('${GITHUB_SHA}', '${GIT_BASE_SHA}'))"
+          cat codal.json
+      # We keep the codal-microbit-v2 library as we need to manually checked the right base commit
+      - name: Checkout correct version of codal-microbit-v2
+        run: |
+          cd libraries/codal-microbit-v2
+          git checkout ${GIT_BASE_SHA}
+      - name: Build 'base' project using build.py
+        run: python build.py --clean
+      - name: Run Bloaty to compare before and after ELF files
+        id: bloaty-comparison
+        uses: carlosperate/bloaty-action@v0
+        with:
+          bloaty-args: -s vm original-build/MICROBIT.elf -- build/MICROBIT
+          output-to-summary: true
+      - name: Add comment to PR with the bloaty diff
+        if: ${{ github.event.pull_request }}
+        continue-on-error: true
+        uses: actions/github-script@v6
+        with:
+          script: |
+            let prComment = '## Build diff\n' +
+              'Base commit: [${{ env.GIT_BASE_SHA }}](${{ github.server_url }}/${{ github.repository }}/commit/${{ env.GIT_BASE_SHA }})\n' +
+              'Action run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\n' +
+              '```\n' +
+              '${{ steps.bloaty-comparison.outputs.bloaty-output-encoded }}' +
+              '```\n'
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: prComment
+            })


### PR DESCRIPTION
This PR uses Google's Bloaty McBloatface to analyse the MICROBIT elf files for memory consumption.

It also builds the PR base commit, or the commit parent, to do a diff and see the additional memory consumed or saved, and adds both analyses to the Action work summary.

And in the case of being a PR (like this one) it will post the diff as a comment.
To show this diff, the initial commit in this PR will contain a bit of code in MicroBit.cpp to create a 4000 byte array and a loop to write some data into it. So, the first bot comment will show the PR as increasing the .bss and .text sections.
I will then force push an update removing this code changes and the bot will post another comment showing the PR didn't increase the build size. 


Screenshot of a summary added to the each action run:

![image](https://user-images.githubusercontent.com/29712657/216285376-334563b3-94ab-4112-ac39-2c1e8ee53c53.png)
 