### PR TITLE
CI: Add workflow to calculate build size diff before & after PR/commit.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,11 +43,10 @@ jobs:
           repository: 'lancaster-university/microbit-v2-samples'
       # We need to use the checkout action (instead of build.py cloning the
       # repository) so that on PRs we can get the commit from the PR merge
-      - name: Clone the this repository in the libraries folder
+      - name: Clone this repository in the libraries folder
         uses: actions/checkout@v3
         with:
           path: libraries/codal-microbit-v2
-          fetch-depth: '0'
       # Changing the commit SHA might be unnecessary, as we've already cloned this
       # repo, but could be useful to ensure codal.json points to the same commit
       - name: Modify codal.json files to use this codal-microbit-v2 commit
@@ -55,13 +54,15 @@ jobs:
         run: |
           echo "codal.json before:"
           cat codal.json
-          python -c "import pathlib; \
-                     f1 = pathlib.Path('codal.json'); \
-                     f1.write_text(f1.read_text().replace(',\n        \"dev\": true', '')); \
-                     f1.write_text(f1.read_text().replace('master', '${GITHUB_SHA}')); \
-                     f2 = pathlib.Path('codal.ble.json'); \
-                     f2.write_text(f2.read_text().replace('master', '${GITHUB_SHA}')); \
-                     f2.write_text(f2.read_text().replace(',\n        \"dev\": true', ''))"
+          python - << EOF
+          import pathlib
+          for codal_file in ['codal.json', 'codal.ble.json']:
+              f = pathlib.Path(codal_file)
+              f.write_text(f.read_text() \
+                  .replace('lancaster-university/codal-microbit-v2', '${GITHUB_REPOSITORY}') \
+                  .replace('master', '${GITHUB_SHA}') \
+                  .replace(',\n        \"dev\": true', ''))
+          EOF
           echo "codal.json after:"
           cat codal.json
       - name: Build default (non-ble) project using build.py

--- a/.github/workflows/size-diff.yml
+++ b/.github/workflows/size-diff.yml
@@ -1,0 +1,133 @@
+name: Bloaty size diff
+
+on:
+  pull_request:
+    branches: '*'
+  push:
+    branches: '*'
+
+jobs:
+  size-diff:
+    name: Run Bloaty
+    runs-on: ubuntu-latest
+    steps:
+      #########################
+      # Install the toolchain #
+      #########################
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.8'
+      - name: Setup arm-none-eabi-gcc 10.3
+        uses: carlosperate/arm-none-eabi-gcc-action@v1
+        with:
+          release: 10.3-2021.10
+      - name: Install Ninja 1.11 & CMake 3.25 via PyPI
+        run: python -m pip install ninja==1.11.1 cmake==3.25.0
+
+      #########################################
+      # Set up the CODAL project and build it #
+      #########################################
+      - name: Clone the microbit-v2-samples repository
+        uses: actions/checkout@v3
+        with:
+          repository: 'lancaster-university/microbit-v2-samples'
+      # We need to use the checkout action (instead of build.py cloning the
+      # repository) so that on PRs we can get the commit from the PR merge
+      - name: Clone this repository in the libraries folder
+        uses: actions/checkout@v3
+        with:
+          path: libraries/codal-microbit-v2
+          fetch-depth: '0'
+      # Changing the commit SHA might be unnecessary, as we've already cloned this
+      # repo, but could be useful to ensure codal.json points to the same commit
+      - name: Modify files to use BLE & this codal-microbit-v2 commit
+        shell: bash
+        run: |
+          echo "coda.json before:"
+          cat codal.json
+          mv codal.ble.json codal.json
+          python - << EOF
+          import pathlib;
+          f = pathlib.Path('codal.json');
+          f.write_text(f.read_text() \
+              .replace('lancaster-university/codal-microbit-v2', '${GITHUB_REPOSITORY}') \
+              .replace('master', '${GITHUB_SHA}') \
+              .replace(',\n        \"dev\": true', ''))
+          f = pathlib.Path('source/main.cpp')
+          f.write_text(f.read_text().replace('out_of_box_experience()', 'ble_test()'))
+          EOF
+          echo "coda.json after:"
+          cat codal.json
+      - name: Build using build.py
+        run: python build.py
+      - name: Save ELF file in a different directory
+        run: |
+          mkdir original-build
+          mv build/MICROBIT original-build/MICROBIT.elf
+      # Manually clean the project, but keep the codal-microbit-v2 library
+      # If the codal-microbit-v2 target adds more libs this step will need to include them as well
+      - name: Clean project
+        run: rm -rf build/ libraries/codal-core libraries/codal-microbit-nrf5sdk libraries/codal-nrf52
+
+      ####################################################################
+      # Set up codal-microbit-v2 to a parent/base commit and build again #
+      ####################################################################
+      - name: "PR only: Get base commit SHA"
+        if: ${{ github.event.pull_request.base.sha }}
+        run: |
+          echo "${{ github.event.pull_request.base.sha }}"
+          echo "GIT_BASE_SHA=${{ github.event.pull_request.base.sha }}" >> $GITHUB_ENV
+          echo "# Bloaty comparison with PR base commit" >> $GITHUB_STEP_SUMMARY
+          echo "Base commit: ${{ github.event.pull_request.base.sha }}" >> $GITHUB_STEP_SUMMARY
+      - name: "Commit only: Get parent commit SHA"
+        if: ${{ ! github.event.pull_request.base.sha }}
+        run: |
+          cd libraries/codal-microbit-v2
+          echo "$(git log --pretty=%P -n 1 HEAD^0)"
+          echo "GIT_BASE_SHA=$(git log --pretty=%P -n 1 HEAD^0)" >> $GITHUB_ENV
+          echo "# Bloaty comparison with parent commit" >> $GITHUB_STEP_SUMMARY
+          echo "Parent commit: $(git log --pretty=%P -n 1 HEAD^0)" >> $GITHUB_STEP_SUMMARY
+      # We don't need to update codal.json because we've kept the
+      # codal-microbit-v2 repo and we manually check out the right base commit
+      - name: Checkout parent/base commit of codal-microbit-v2
+        run: |
+          cd libraries/codal-microbit-v2
+          git checkout ${GIT_BASE_SHA}
+      - name: Build 'base' project using build.py
+        run: python build.py --clean
+
+      #######################################
+      # Run the Bloaty McBloatface analysis #
+      #######################################
+      # 1st run the bloaty diff so that it's added to the top of the summary page
+      - name: Run Bloaty to compare before and after ELF files
+        id: bloaty-comparison
+        uses: carlosperate/bloaty-action@v1
+        with:
+          bloaty-args: -s vm original-build/MICROBIT.elf -- build/MICROBIT
+          output-to-summary: true
+      # Then show memory consumption of top 30 components for this build
+      - name: Run Bloaty to view ELF file full info
+        uses: carlosperate/bloaty-action@v1
+        with:
+          bloaty-args: original-build/MICROBIT.elf -d compileunits -n 30 -s vm
+          output-to-summary: true
+      - name: Add comment to PR with the bloaty diff
+        if: ${{ github.event.pull_request }}
+        continue-on-error: true
+        uses: actions/github-script@v6
+        with:
+          script: |
+            let prComment = '## Build diff\n' +
+              'Base commit: [${{ env.GIT_BASE_SHA }}](${{ github.server_url }}/${{ github.repository }}/commit/${{ env.GIT_BASE_SHA }})\n' +
+              'Action run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\n' +
+              '```\n' +
+              '${{ steps.bloaty-comparison.outputs.bloaty-output-encoded }}' +
+              '```\n'
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: prComment
+            })


### PR DESCRIPTION
This PR uses Google's Bloaty McBloatface to analyse the MICROBIT elf file for memory consumption.

It also builds the PR base commit, or the commit parent, to do a diff and see the additional memory consumed or saved.

In the case of being a PR from a branch in this repository (not forks) it will post the diff as a comment as well.

To show an example diff in this PR (instead of an output just showing "no change in size"), the initial commit will contain a bit of code in MicroBit.cpp to create a 4000 byte array and a loop to write some data into it. So, the first bot comment will show the PR as increasing the `.bss` and `.text` sections.
I will then force push an update removing this code and the bot will post another comment showing a zero size increase. 


Both bloaty analysis outputs are added to to the Action work summary, so even PRs from forks will have this info (even if they don't get a PR comment):

![image](https://user-images.githubusercontent.com/29712657/216330832-29550cdf-e738-4f3f-baa5-1eca4132a83a.png)

 