### PR TITLE
radio: Reduce power level options to match V1 DAL.

### DIFF
--- a/inc/MicroBitRadio.h
+++ b/inc/MicroBitRadio.h
@@ -69,12 +69,12 @@ namespace codal
 // Default configuration values
 #define MICROBIT_RADIO_BASE_ADDRESS             0x75626974
 #define MICROBIT_RADIO_DEFAULT_GROUP            0
-#define MICROBIT_RADIO_DEFAULT_TX_POWER         7
+#define MICROBIT_RADIO_DEFAULT_TX_POWER         6
 #define MICROBIT_RADIO_DEFAULT_FREQUENCY        7
 #define MICROBIT_RADIO_MAX_PACKET_SIZE          32
 #define MICROBIT_RADIO_HEADER_SIZE              4
 #define MICROBIT_RADIO_MAXIMUM_RX_BUFFERS       4
-#define MICROBIT_RADIO_POWER_LEVELS             10
+#define MICROBIT_RADIO_POWER_LEVELS             8
 
 // Known Protocol Numbers
 #define MICROBIT_RADIO_PROTOCOL_DATAGRAM        1       // A simple, single frame datagram. a little like UDP but with smaller packets. :-)

--- a/source/MicroBitRadio.cpp
+++ b/source/MicroBitRadio.cpp
@@ -32,7 +32,7 @@ DEALINGS IN THE SOFTWARE.
 
 using namespace codal;
 
-const uint8_t MICROBIT_RADIO_POWER_LEVEL[] = {0xD8, 0xD8, 0xEC, 0xF0, 0xF4, 0xF8, 0xFC, 0x00, 0x03, 0x04};
+const uint8_t MICROBIT_RADIO_POWER_LEVEL[] = {0xD8, 0xEC, 0xF0, 0xF4, 0xF8, 0xFC, 0x00, 0x04};
 
 /**
   * Provides a simple broadcast radio abstraction, built upon the raw nrf51822 RADIO module.


### PR DESCRIPTION
As discussed in:
- https://github.com/lancaster-university/codal-microbit-v2/issues/260

This change more closely matches the input values for `MicroBitRadio::setTransmitPower()` that micro:bit V1 DAL has, so code trying to achieve the max possible value (`uBit.radio.setTransmitPower(7)`) works correctly in both V1 & V2.

I'll leave the PR in draft state until the discussion in https://github.com/lancaster-university/codal-microbit-v2/issues/260 is completed.