### PR TITLE
MicroBitCompassCalibrator - avoid using max(int,int)

### DIFF
--- a/source/MicroBitCompassCalibrator.cpp
+++ b/source/MicroBitCompassCalibrator.cpp
@@ -185,7 +185,8 @@ CompassCalibration MicroBitCompassCalibrator::spherify(Sample3D centre, Sample3D
         // will place this point on the surface of the sphere.
         float s = (radius / d) - 1;
 
-        scale = max(scale, s);
+        if (scale < s)
+            scale = s;
 
         // next, determine the scale effect this has on each of our components.
         float dx = (data[i].x - centre.x); 


### PR DESCRIPTION
See https://github.com/lancaster-university/codal-microbit-v2/issues/286#issuecomment-1484223018