### PR TITLE
CI MakeCode: Use the default `pxt-core` and `pxt-common-packages` from `package.json`

### DIFF
--- a/.github/workflows/makecode.yml
+++ b/.github/workflows/makecode.yml
@@ -50,8 +50,6 @@ jobs:
         run: |
           npm install -g pxt
           npm install
-          # Running from pxt-microbit main branch, so use latest release of these packages
-          npm install pxt-core@latest pxt-common-packages@latest
       - name: Edit pxtarget.json to use this repository and commit
         shell: bash
         run: |


### PR DESCRIPTION
For the MakeCode developer instructions they recommend to clone the repost and use the latest commit from the main branch, so the CI was installing the latest versions submitted to npm. However, the projects can be slightly out of sync and cause build problems:
- https://github.com/lancaster-university/codal-microbit-v2/actions/runs/4755748371/attempts/1

Relaying on the `pxt-core` and `pxt-common-packages` versions installed from `package.json` should be more stable.