### PR TITLE
CI MicroPython: Don't checkout submodules recursively.

### DIFF
--- a/.github/workflows/micropython.yml
+++ b/.github/workflows/micropython.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: 'microbit-foundation/micropython-microbit-v2'
-          submodules: 'recursive'
+          submodules: 'true'
       - name: Setup arm-none-eabi-gcc v10.3
         uses: carlosperate/arm-none-eabi-gcc-action@v1
         with:


### PR DESCRIPTION
Is not necessary and as MicroPython contains a lot of submodules with SDKs and similar it takes a long time to pull submodules recursively.

With this change CI build time goes down from 8 to 1 minute.

<img width="1243" alt="image" src="https://github.com/lancaster-university/codal-microbit-v2/assets/29712657/0bddcc6d-bd35-4de6-b24f-0ab308f6cf8a">
