### PR TITLE
CI: Update size diff workflow to let you configure the samples commit.

### DIFF
--- a/.github/workflows/size-diff.yml
+++ b/.github/workflows/size-diff.yml
@@ -14,6 +14,10 @@ on:
         description: '(Optional) New commit to use instead of branch HEAD'
         required: false
         default: ''
+      samples-commit:
+          description: '(Optional) microbit-v2-samples commit to use instead of branch HEAD'
+          required: false
+          default: ''
 
 jobs:
   size-diff:
@@ -41,6 +45,9 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: 'lancaster-university/microbit-v2-samples'
+          # Unless manually triggered via workflow_dispatch this will be an empty
+          # string, checking out the default branch
+          ref: ${{ github.event.inputs.samples-commit }}
       # We need to use the checkout action (instead of build.py cloning the
       # repository) so that on PRs we can get the commit from the PR merge
       - name: Clone this repository in the libraries folder
@@ -101,6 +108,7 @@ jobs:
           echo "# Bloaty comparison with input commit(s)" >> $GITHUB_STEP_SUMMARY
           echo "Old commit: [${{ github.event.inputs.old-commit }}](https://github.com/${GITHUB_REPOSITORY}/commit/${{ github.event.inputs.old-commit }})" >> $GITHUB_STEP_SUMMARY
           echo "New commit: [${{ github.event.inputs.new-commit || github.sha }}](https://github.com/${GITHUB_REPOSITORY}/commit/${{ github.event.inputs.new-commit || github.sha}})" >> $GITHUB_STEP_SUMMARY
+          echo "Samples commit: ${{ github.event.inputs.samples-commit || 'main branch HEAD' }}" >> $GITHUB_STEP_SUMMARY
           echo "Full diff: https://github.com/${GITHUB_REPOSITORY}/compare/${{ github.event.inputs.old-commit }}...${{ github.event.inputs.new-commit || github.sha}}" >> $GITHUB_STEP_SUMMARY
       - name: "Commit only: Get parent commit SHA"
         if: ${{ ! github.event.pull_request.base.sha && github.event_name != 'workflow_dispatch'}}


### PR DESCRIPTION
New additions to the samples repo that use newer APIs will cause build failures in the "size diff" workflow, as it might be configured to compile an older versions of CODAL without those APIs.
This is currently the case, as new asserts have been added to CODAL and the samples repo, so any comparison with older CODAL tags will fail.

So, this PR adds another entry to the form to optionally specify a samples repo commit (bottom one in this screenshot):
<img width="363" alt="image" src="https://github.com/lancaster-university/codal-microbit-v2/assets/29712657/fe80de0b-6d8d-445d-94c8-c304454da84c">
