### PR TITLE
BLE: Simplify device name string creation.

### DIFF
--- a/source/bluetooth/MicroBitBLEManager.cpp
+++ b/source/bluetooth/MicroBitBLEManager.cpp
@@ -436,10 +436,7 @@ void MicroBitBLEManager::init( ManagedString deviceName, ManagedString serialNum
 #if CONFIG_ENABLED(MICROBIT_BLE_DEVICE_INFORMATION_SERVICE)
     MICROBIT_DEBUG_DMESG( "DEVICE_INFORMATION_SERVICE");
 
-    ManagedString modelVersion("V2");
-    ManagedString disName( MICROBIT_BLE_MODEL);
-    disName = disName + " " + modelVersion;
-
+    ManagedString disName(MICROBIT_BLE_MODEL + ManagedString(" V2"));
     ble_dis_init_t disi;
     memset( &disi, 0, sizeof(disi));
     disi.dis_char_rd_sec = SEC_OPEN;


### PR DESCRIPTION
Saw this when looking at https://github.com/lancaster-university/codal-microbit-v2/issues/370, it's a small change that results in the same string, but it saves a bit of flash with gcc v10.3.

The bloatly CI workflow should post here the size diff.

The `modelVersion` instance is not used anywhere else, `disName` results in the same string and is not used anywhere else either.