### PR TITLE
Add 'show_size' option to target.json file to print build size info.

### DIFF
--- a/target-locked.json
+++ b/target-locked.json
@@ -72,6 +72,7 @@
     "linker_flags": "-Wl,--no-wchar-size-warning -Wl,--gc-sections -Wl,--wrap,atexit -mcpu=cortex-m4 -mthumb -mfpu=fpv4-sp-d16 -mfloat-abi=softfp -Wl,--start-group -lstdc++ -lsupc++ -lm -lc -lgcc -lnosys -Wl,--end-group",
     "post_process": "",
     "processor": "NRF52833",
+    "show_size": true,
     "snapshot_version": "v0.2.69",
     "toolchain": "ARM_GCC"
 }

--- a/target.json
+++ b/target.json
@@ -6,6 +6,7 @@
     "post_process":"",
     "generate_bin":true,
     "generate_hex":true,
+    "show_size":true,
     "config":{
         "MBED_CONF_NORDIC_NRF_LF_CLOCK_SRC": "NRF_LF_SRC_XTAL",
         "CONFIG_GPIO_AS_PINRESET": 1,


### PR DESCRIPTION
If we decide to merge this CODAL build system feature, this is how to activate it:
- https://github.com/lancaster-university/microbit-v2-samples/pull/81

Discussions are probably better over that PR.