### PR TITLE
CI: Update versions of actions to remove warnings about node 16.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     name: ${{ matrix.os }}, gcc ${{ matrix.gcc }}, cmake ${{ matrix.cmake || 'latest'}}
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.8'
       - name: Setup arm-none-eabi-gcc ${{ matrix.gcc }}
@@ -26,7 +26,7 @@ jobs:
         with:
           release: ${{ matrix.gcc }}
       - name: Setup CMake ${{ matrix.cmake }}
-        uses: jwlawson/actions-setup-cmake@v1
+        uses: jwlawson/actions-setup-cmake@v2
         with:
           cmake-version: ${{ matrix.cmake }}
       - name: Install latest Ninja release via PyPI
@@ -38,13 +38,13 @@ jobs:
           ninja --version
           python --version
       - name: Clone the microbit-v2-samples repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: 'lancaster-university/microbit-v2-samples'
       # We need to use the checkout action (instead of build.py cloning the
       # repository) so that on PRs we can get the commit from the PR merge
       - name: Clone this repository in the libraries folder
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: libraries/codal-microbit-v2
           submodules: 'recursive'
@@ -70,7 +70,7 @@ jobs:
         run: python build.py
       - name: Upload non-ble hex file
         if: runner.os == 'Windows' && matrix.gcc == 'latest' && matrix.cmake == ''
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: codal-microbit-v2-${{ github.sha }}
           path: MICROBIT.hex
@@ -89,7 +89,7 @@ jobs:
         run: python build.py --clean
       - name: Upload BLE hex file
         if: runner.os == 'Windows' && matrix.gcc == 'latest' && matrix.cmake == ''
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: codal-microbit-v2-BLE-${{ github.sha }}
           path: MICROBIT.hex

--- a/.github/workflows/micropython.yml
+++ b/.github/workflows/micropython.yml
@@ -12,7 +12,7 @@ jobs:
     name: Build MicroPython
     steps:
       - name: Clone MicroPython
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: 'microbit-foundation/micropython-microbit-v2'
           submodules: 'true'
@@ -60,7 +60,7 @@ jobs:
           cd src
           make -j4
       - name: Upload hex file
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: micropython-${{ github.sha }}.hex
           path: src/MICROBIT.hex

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-20.04
     name: Build against Ubuntu-20.04 for release assets
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install CppCheck
         run: |
           sudo apt-get update
@@ -22,7 +22,7 @@ jobs:
           release: latest
       
       - name: Setup CMake
-        uses: jwlawson/actions-setup-cmake@v1
+        uses: jwlawson/actions-setup-cmake@v2
       
       - name: Build default project using build.py
         run: python build.py

--- a/.github/workflows/size-diff.yml
+++ b/.github/workflows/size-diff.yml
@@ -28,7 +28,7 @@ jobs:
       # Install the toolchain #
       #########################
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.8'
       - name: Setup arm-none-eabi-gcc 10.3
@@ -42,7 +42,7 @@ jobs:
       # Set up the CODAL project and build it #
       #########################################
       - name: Clone the microbit-v2-samples repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: 'lancaster-university/microbit-v2-samples'
           # Unless manually triggered via workflow_dispatch this will be an empty
@@ -51,7 +51,7 @@ jobs:
       # We need to use the checkout action (instead of build.py cloning the
       # repository) so that on PRs we can get the commit from the PR merge
       - name: Clone this repository in the libraries folder
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: libraries/codal-microbit-v2
           fetch-depth: '0'
@@ -157,7 +157,7 @@ jobs:
       - name: "PR only: Add comment to PR with the bloaty diff"
         if: ${{ github.event.pull_request }}
         continue-on-error: true
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             let prComment = '## Build diff\n' +

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - run: python3 -m pip install natsort


### PR DESCRIPTION
Warnings example:
https://github.com/lancaster-university/codal-microbit-v2/actions/runs/8066928871
![image](https://github.com/lancaster-university/codal-microbit-v2/assets/29712657/3d678b82-53be-4288-8124-3e0221ef94f9)
