### PR TITLE
Implement microbit_dal_version() and set MICROBIT_DAL_VERSION.

### DIFF
--- a/inc/MicroBitConfig.h
+++ b/inc/MicroBitConfig.h
@@ -288,7 +288,11 @@
 // if this isn't available, it can be defined manually as a configuration option.
 //
 #ifndef MICROBIT_DAL_VERSION
-    #define MICROBIT_DAL_VERSION                    "unknown"
+    #ifdef DEVICE_DAL_VERSION
+        #define MICROBIT_DAL_VERSION                DEVICE_DAL_VERSION
+    #else
+        #define MICROBIT_DAL_VERSION                "unknown"
+    #endif
 #endif
 
 // Allow USB serial events to wake the board from deep sleep.

--- a/source/MicroBitDevice.cpp
+++ b/source/MicroBitDevice.cpp
@@ -192,6 +192,10 @@ __NO_RETURN void microbit_reset()
     for (;;);
 }
 
+const char * microbit_dal_version() {
+    return MICROBIT_DAL_VERSION;
+}
+
 /**
   * Seed the random number generator (RNG).
   *


### PR DESCRIPTION
To properly get the CODAL version this PR  also needs:
- ~~https://github.com/lancaster-university/microbit-v2-samples/pull/87~~
- https://github.com/lancaster-university/codal-core/pull/169#issuecomment-2056825233

Without that PR it should still work, but the version will still be set to `"unknown"`.


```cpp
int main() {
    uBit.init();

    uBit.serial.printf("CODAL_VERSION: %s\n", CODAL_VERSION);
    uBit.serial.printf("CODAL_VERSION_LONG: %s\n", CODAL_VERSION_LONG);
    uBit.serial.printf("DEVICE_DAL_VERSION: %s\n", DEVICE_DAL_VERSION);
    uBit.serial.printf("MICROBIT_DAL_VERSION: %s\n", MICROBIT_DAL_VERSION);
    uBit.serial.printf("microbit_dal_version(): %s\n", microbit_dal_version());
    uBit.serial.printf("uBit.getVersion(): %s\n", uBit.getVersion());

    while (true);
}
```