### PR TITLE
Set `uBit.io.logo` to capacitive touch mode by default.

### DIFF
--- a/model/MicroBit.cpp
+++ b/model/MicroBit.cpp
@@ -116,16 +116,13 @@ MicroBit::MicroBit() :
     }
     */
 
-    // Configure serial port for debugging
-
-    //SERIAL_TODO:
-    // serial.set_flow_control(mbed::Serial::Disabled);
-    //serial.baud(115200);
-
     // Enable the serial port as a deep sleep wake event. (Useful for MicroPython REPL, for example)
     #if CONFIG_ENABLED(MICROBIT_USB_SERIAL_WAKE)
         serial.status |= CODAL_SERIAL_STATUS_DEEPSLEEP;
     #endif
+
+    // uBit.logo is a Capacitive TouchButton, ensure the io pin is set capacitive as well
+    io.logo.status |= IO_STATUS_CAPACITATIVE_TOUCH;
 
     // Add pullup resisitor to IRQ line (it's floating ACTIVE LO)
     io.irq1.getDigitalValue();


### PR DESCRIPTION
@finneyj this would be the simplest way set the io.logo pin capacitive, do you think it should be behind a build flag as well? If so, what would be the best name for it? `MICROBIT_PIN_LOGO_CAPACITIVE`?
In that case we would still like to make sure the default value is set to capacitive, so the flag would be mostly used to disable this feature?