### PR TITLE
Enable the Utility Service by default.

### DIFF
--- a/inc/MicroBitConfig.h
+++ b/inc/MicroBitConfig.h
@@ -259,13 +259,13 @@
 //
 // This is currently **BETA** and will be enabled by default in the future.
 #ifndef MICROBIT_BLE_UTILITY_SERVICE_PAIRING
-#define MICROBIT_BLE_UTILITY_SERVICE_PAIRING 0
+    #define MICROBIT_BLE_UTILITY_SERVICE_PAIRING 1
 #endif
 
 // Enable/Disable BLE Service in application mode: MicroBitUtilityService
 // Set '1' to enable.
 #ifndef MICROBIT_BLE_UTILITY_SERVICE
-#define MICROBIT_BLE_UTILITY_SERVICE 0
+    #define MICROBIT_BLE_UTILITY_SERVICE 1
 #endif
 
 // Enable/Disable Nordic Firmware style BLE based UART implimentation.


### PR DESCRIPTION
So that it works like this in the different environments:
- C++ CODAL programmes: Enabled by default
- MicroPython: Enabled by default on pairing mode (BLE only enabled in pairing mode)
- MakeCode: To be updated to disable this flags in normal programmes to save some memory, and adding the datalog extension enables them again

Part of:
- https://github.com/lancaster-university/codal-microbit-v2/issues/354