### PR TITLE
Addition of getRows() and getNumberOfRows() feature to the datalogger.

### DIFF
--- a/inc/MicroBitLog.h
+++ b/inc/MicroBitLog.h
@@ -366,7 +366,7 @@ namespace codal
         * @param fromRowIndex 0-based index of starting row
         * @return number of rows + header from fromRowIndex
         */
-        uint32_t getNumberOfRows(uint32_t fromRowIndex = 0);
+        uint32_t getNumberOfRows(uint32_t fromRowIndex);
 
         /**
         * Get n rows (first row is header) worth of logged data as a ManagedString

--- a/inc/MicroBitLog.h
+++ b/inc/MicroBitLog.h
@@ -374,7 +374,7 @@ namespace codal
         * @param nRows number of rows to get from fromRowIndex
         * @return ManagedString of all data in these rows, each column separated by a newline
         */
-        ManagedString getRows(uint32_t fromRowIndex, uint32_t nRows);
+        ManagedString getRows(uint32_t fromRowIndex, int nRows);
 
     private:
 

--- a/inc/MicroBitLog.h
+++ b/inc/MicroBitLog.h
@@ -362,17 +362,17 @@ namespace codal
         int readData(void *data, uint32_t index, uint32_t len, DataFormat format, uint32_t length);
 
         /**
-        * Get the number of rows (including the header) that exist in the datalog.
-        * @param fromRowIndex 0-based index of starting row: bumped up to 0 if negative
-        * @return number of rows + header from fromRowIndex
+        * Get the number of rows (including the header) in the datalogger.
+        * @param fromRowIndex 0-based index of starting row: bumped up to 0 if negative.
+        * @return number of rows + header.
         */
         uint32_t getNumberOfRows(uint32_t fromRowIndex = 0);
 
         /**
-        * Get n rows (first row is header) worth of logged data as a ManagedString
-        * @param fromRowIndex 0-based index of starting row
-        * @param nRows number of rows to get from fromRowIndex
-        * @return ManagedString between the parameter range, each row separated by a newline, each column by a comma
+        * Get n rows worth of logged data as a ManagedString.
+        * @param fromRowIndex 0-based index of starting row.
+        * @param nRows number of rows to get from fromRowIndex.
+        * @return ManagedString between the parameter range, each row separated by a newline, each column by a comma.
         */
         ManagedString getRows(uint32_t fromRowIndex, int nRows);
 

--- a/inc/MicroBitLog.h
+++ b/inc/MicroBitLog.h
@@ -374,12 +374,6 @@ namespace codal
         * @return ManagedString of all data in these rows, each column separated by a '_'
         */
         ManagedString getRows(uint32_t fromRowIndex, uint32_t nRows);
-        
-        /**
-        * Get all the logged data as a ManagedString.
-        * Each element is seperated by a '_'
-        */
-        ManagedString getData();
 
     private:
 

--- a/inc/MicroBitLog.h
+++ b/inc/MicroBitLog.h
@@ -363,10 +363,10 @@ namespace codal
 
         /**
         * Get the number of rows (including the header) that exist in the datalog.
-        * @param fromRowIndex 0-based index of starting row
+        * @param fromRowIndex 0-based index of starting row: bumped up to 0 if negative
         * @return number of rows + header from fromRowIndex
         */
-        uint32_t getNumberOfRows(uint32_t fromRowIndex);
+        uint32_t getNumberOfRows(uint32_t fromRowIndex = 0);
 
         /**
         * Get n rows (first row is header) worth of logged data as a ManagedString

--- a/inc/MicroBitLog.h
+++ b/inc/MicroBitLog.h
@@ -361,13 +361,17 @@ namespace codal
          */
         int readData(void *data, uint32_t index, uint32_t len, DataFormat format, uint32_t length);
 
+        /**
+        * Get the number of rows (including the header) that exist in the datalog.
+        */
         uint32_t getNumberOfRows();
 
         /**
         * Get n rows worth of logged data as a ManagedString
-        * Each element is seperated by a _
+        * 
+        * Each element in the returned string is seperated by a _
         */
-        ManagedString getNRows(uint32_t fromRowIndex, uint32_t nRows);
+        ManagedString getRows(uint32_t fromRowIndex, uint32_t nRows);
         
 
         /**

--- a/inc/MicroBitLog.h
+++ b/inc/MicroBitLog.h
@@ -361,6 +361,7 @@ namespace codal
          */
         int readData(void *data, uint32_t index, uint32_t len, DataFormat format, uint32_t length);
 
+        uint32_t getNumberOfRows();
 
         /**
         * Get n rows worth of logged data as a ManagedString
@@ -371,7 +372,7 @@ namespace codal
 
         /**
         * Get all the logged data as a ManagedString.
-        * Each element is seperated by a _
+        * Each element is seperated by a newline
         */
         ManagedString getData();
 

--- a/inc/MicroBitLog.h
+++ b/inc/MicroBitLog.h
@@ -372,7 +372,7 @@ namespace codal
         * Get n rows (first row is header) worth of logged data as a ManagedString
         * @param fromRowIndex 0-based index of starting row
         * @param nRows number of rows to get from fromRowIndex
-        * @return ManagedString of all data in these rows, each column separated by a newline
+        * @return ManagedString between the parameter range, each row separated by a newline, each column by a comma
         */
         ManagedString getRows(uint32_t fromRowIndex, int nRows);
 

--- a/inc/MicroBitLog.h
+++ b/inc/MicroBitLog.h
@@ -363,20 +363,21 @@ namespace codal
 
         /**
         * Get the number of rows (including the header) that exist in the datalog.
+        * @return number of rows + header
         */
         uint32_t getNumberOfRows();
 
         /**
         * Get n rows worth of logged data as a ManagedString
-        * 
-        * Each element in the returned string is seperated by a _
+        * @param fromRowIndex 0-based index of starting row
+        * @param nRows number of rows to get from fromRowIndex
+        * @return ManagedString of all data in these rows, each column separated by a '_'
         */
         ManagedString getRows(uint32_t fromRowIndex, uint32_t nRows);
         
-
         /**
         * Get all the logged data as a ManagedString.
-        * Each element is seperated by a newline
+        * Each element is seperated by a '_'
         */
         ManagedString getData();
 

--- a/inc/MicroBitLog.h
+++ b/inc/MicroBitLog.h
@@ -364,15 +364,15 @@ namespace codal
         /**
         * Get the number of rows (including the header) that exist in the datalog.
         * @param fromRowIndex 0-based index of starting row
-        * @return number of rows + header
+        * @return number of rows + header from fromRowIndex
         */
-        uint32_t getNumberOfRows(uint32_t fromRowIndex);
+        uint32_t getNumberOfRows(uint32_t fromRowIndex = 0);
 
         /**
-        * Get n rows worth of logged data as a ManagedString
+        * Get n rows (first row is header) worth of logged data as a ManagedString
         * @param fromRowIndex 0-based index of starting row
         * @param nRows number of rows to get from fromRowIndex
-        * @return ManagedString of all data in these rows, each column separated by a '_'
+        * @return ManagedString of all data in these rows, each column separated by a newline
         */
         ManagedString getRows(uint32_t fromRowIndex, uint32_t nRows);
 

--- a/inc/MicroBitLog.h
+++ b/inc/MicroBitLog.h
@@ -363,9 +363,10 @@ namespace codal
 
         /**
         * Get the number of rows (including the header) that exist in the datalog.
+        * @param fromRowIndex 0-based index of starting row
         * @return number of rows + header
         */
-        uint32_t getNumberOfRows();
+        uint32_t getNumberOfRows(uint32_t fromRowIndex);
 
         /**
         * Get n rows worth of logged data as a ManagedString

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1208,7 +1208,7 @@ ManagedString MicroBitLog::getNRows(uint32_t fromRowIndex, uint32_t nRows)
         end++;
     }
 
-    const uint32_t dataLength = endOfDataChunk - startOfRowN;
+    const uint32_t dataLength = endOfDataChunk - dataStart;
     void *rowData = malloc(dataLength * sizeof(char*));
     cache.read(startOfRowN, rowData, dataLength);
     return cleanBuffer((char*) rowData, dataLength);

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1187,27 +1187,28 @@ ManagedString MicroBitLog::getNRows(uint32_t fromRowIndex, uint32_t nRows)
     uint32_t end = dataStart;
     uint32_t rowSeparatorCount = 0;
     uint8_t c = 0;
-    // while(c != 0xff)
-    // {
-    //     cache.read(end, &c, 1);
+    while(c != 0xff)
+    {
+        cache.read(end, &c, 1);
 
-    //     if (c == rowSeparator) {
-    //         rowSeparatorCount++;
-    //         if (!startRowFound && rowSeparatorCount == fromRowIndex) 
-    //         {
-    //             startRowFound = true;
-    //             startOfRowN = end;
-    //         }
+        if (c == rowSeparator) {
+            rowSeparatorCount++;
+            if (!startRowFound && rowSeparatorCount == fromRowIndex) 
+            {
+                startRowFound = true;
+                startOfRowN = end;
+                break;
+            }
 
-    //         else if (rowSeparatorCount == rowSeparatorTargetCount) 
-    //         {
-    //             endOfDataChunk = end;
-    //             break;
-    //         }
-    //     }
+            // else if (rowSeparatorCount == rowSeparatorTargetCount) 
+            // {
+            //     endOfDataChunk = end;
+            //     break;
+            // }
+        }
 
-    //     end++;
-    // }
+        end++;
+    }
 
     // startOfRowN = dataStart + 8;
     const int dataLength = endOfDataChunk - startOfRowN;

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1141,9 +1141,9 @@ int MicroBitLog::_readSource( uint8_t *&data, uint32_t &index, uint32_t &len, ui
 
 
 /**
-* Get the number of rows (including the header) that exist in the datalog.
-* @param fromRowIndex 0-based index of starting row: bumped up to 0 if negative
-* @return number of rows + header
+* Get the number of rows (including the header) in the datalogger.
+* @param fromRowIndex 0-based index of starting row: bumped up to 0 if negative.
+* @return number of rows + header.
 */
 uint32_t MicroBitLog::getNumberOfRows(uint32_t fromRowIndex)
 {
@@ -1156,7 +1156,7 @@ uint32_t MicroBitLog::getNumberOfRows(uint32_t fromRowIndex)
     // Read read until we see a 0xFF character (unused memory)
     uint8_t c = 0;
     while(c != 0xff)
-    {
+    { 
         cache.read(end, &c, 1);
         if (c == rowSeparator) {
             rowCount++;
@@ -1173,10 +1173,10 @@ uint32_t MicroBitLog::getNumberOfRows(uint32_t fromRowIndex)
 }
 
 /**
-* Get n rows worth of logged data as a ManagedString
-* @param fromRowIndex 0-based index of starting row
-* @param nRows number of rows to get from fromRowIndex
-* @return ManagedString between the parameter range, each row separated by a newline, each column by a comma
+* Get n rows worth of logged data as a ManagedString.
+* @param fromRowIndex 0-based index of starting row.
+* @param nRows number of rows to get from fromRowIndex.
+* @return ManagedString between the parameter range, each row separated by a newline, each column by a comma.
 */
 ManagedString MicroBitLog::getRows(uint32_t fromRowIndex, int nRows)
 {

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -24,8 +24,6 @@ DEALINGS IN THE SOFTWARE.
 
 #include "MicroBitLog.h"
 #include "CodalDmesg.h"
-#include <new>
-#include <cstdio>
 
 #define ARRAY_LEN(array)    (sizeof(array) / sizeof(array[0]))
 
@@ -1177,12 +1175,12 @@ uint32_t MicroBitLog::getNumberOfRows(uint32_t fromRowIndex)
 * Get n rows worth of logged data as a ManagedString
 * @param fromRowIndex 0-based index of starting row
 * @param nRows number of rows to get from fromRowIndex
-* @return ManagedString of all data in these rows, each column separated by a '_'
+* @return ManagedString of all data in these rows, each column separated by a newline
 */
 ManagedString MicroBitLog::getRows(uint32_t fromRowIndex, uint32_t nRows)
 {
-    if (fromRowIndex >= dataEnd || nRows == 0)
-        return cleanBuffer("", 0);
+    if (fromRowIndex >= dataEnd || nRows <= 0)
+        return ManagedString("");
 
     constexpr uint8_t rowSeparator = 10; // newline char in asci
     const uint32_t rowSeparatorTargetCount = fromRowIndex + nRows + 1;
@@ -1219,9 +1217,9 @@ ManagedString MicroBitLog::getRows(uint32_t fromRowIndex, uint32_t nRows)
     }
 
     const int dataLength = endOfDataChunk - startOfRowN;
-    void *rowData = malloc(dataLength * sizeof(char*));
-    cache.read(startOfRowN, rowData, dataLength);
-    return cleanBuffer((char*) rowData, dataLength);
+    ManagedBuffer rowData(dataLength);
+    cache.read(startOfRowN, rowData.toCharArray(), dataLength);
+    return rowData;
 }
 
 /**

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1146,10 +1146,6 @@ int MicroBitLog::_readSource( uint8_t *&data, uint32_t &index, uint32_t &len, ui
 */
 uint32_t MicroBitLog::getNumberOfRows(uint32_t fromRowIndex)
 {
-    if (fromRowIndex < 0) {
-        fromRowIndex = 0;
-    }
-
     constexpr uint8_t rowSeparator = 10; // newline char
     uint32_t rowCount = 0;
 
@@ -1184,7 +1180,7 @@ uint32_t MicroBitLog::getNumberOfRows(uint32_t fromRowIndex)
 ManagedString MicroBitLog::getRows(uint32_t fromRowIndex, uint32_t nRows)
 {
     if (fromRowIndex >= dataEnd || nRows <= 0)
-        return ManagedString("", 0);
+        return cleanBuffer("", 0);
 
     constexpr uint8_t rowSeparator = 10; // newline char in asci
     const uint32_t rowSeparatorTargetCount = fromRowIndex + nRows + 1;

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1155,78 +1155,45 @@ ManagedString MicroBitLog::getNRows(uint32_t fromRowIndex, uint32_t nRows)
     }
 
     // Number of columns ('_' separators) to find:
-    constexpr uint32_t colQty = 4;
-    constexpr uint8_t colSeparator = 95; // '_'
+    // constexpr uint32_t colQty = 4;
+    // constexpr uint8_t colSeparator = 95; // '_'
+    constexpr uint8_t rowSeparator = 10; // newline char
 
     // Number of columns expected before the start of the data
-    const uint32_t colTargetStartQty = fromRowIndex * colQty;
-    const uint32_t colTargetEndQty = colTargetStartQty + (nRows * colQty);
-
-    // constexpr uint32_t stdCharChunkSize = 32;
-    // const uint32_t length = dataEnd - dataStart;
-    
-    // bool foundAllRows = false;
-    // uint32_t numberOfLoops = 0;
-    // uint32_t lastColIndex = 0;
-
-    // // This algorithm can be optimised by tracking the number of col's in the prior chunk:
-    // while (!foundAllRows) {
-    //     // Get a chunk of data and search it for the target number of colSeparator's
-    //     // If the chunk is exhausted then expand the chunk
-    //     uint32_t chunkSize = dataEnd;
-    //     // if ((numberOfLoops + 1) * stdCharChunkSize < chunkSize) {
-    //     //     chunkSize = (numberOfLoops + 1) * stdCharChunkSize;
-    //     // }
-    //     chunkSize -= dataStart;
-
-    //     // Load the chunk:
-    //     void *searchChunk = malloc(chunkSize * sizeof(char*));
-    //     cache.read(dataStart, searchChunk, chunkSize);
-    //     ManagedString cleanedChunk = cleanBuffer((char*) searchChunk, chunkSize);
-
-    //     uint32_t colSeparatorQty = 0;
-    //     for(int i = 0; i < cleanedChunk.length(); i++) 
-    //     {    
-    //         if(cleanedChunk.charAt(i) == colSeparator) {
-    //             colSeparatorQty++;
-
-    //             if (colSeparatorQty == colTargetQty) {
-    //                 foundAllRows = true;
-    //                 lastColIndex = i;
-    //             }
-    //         }
-    //     }
-
-    //     numberOfLoops++;
-    // }
+    // const uint32_t colTargetStartQty = fromRowIndex * colQty;
+    // const uint32_t colTargetEndQty = colTargetStartQty + (nRows * colQty);
+    const uint32_t rowTargetEndQty = fromRowIndex + nRows;
 
     uint8_t fromRowNOffset = 0;
     uint8_t endOfRowN = 0;
-    uint32_t colSeparatorQty = 0;
+    // uint32_t colSeparatorQty = 0;
+    uint32_t rowSeparatorQty = 0;
     bool startFound = false;
 
     uint8_t d = 0;
-    uint32_t start = dataStart;
-    while(start < dataEnd)
-    {
-        cache.read(start, &d, 1);
-        if (d == colSeparator)
-        {
-            colSeparatorQty++;
+    uint32_t i = dataStart;
 
-            if (!startFound && colSeparatorQty == colTargetStartQty) 
+    while(i < dataEnd)
+    {
+        cache.read(i, &d, 1);
+        if (d == rowSeparator)
+        {
+            rowSeparatorQty++;
+
+            if (!startFound && rowSeparatorQty == fromRowIndex) 
             {
-                fromRowNOffset = start;
+                startFound = true
+                fromRowNOffset = i;
             }
 
-            else if (colSeparatorQty == colTargetEndQty) 
+            else if (rowSeparatorQty == rowTargetEndQty) 
             {
-                endOfRowN = start;
+                endOfRowN = i;
                 break;
             }
         }
 
-        start++;
+        i++;
     }
 
     const uint32_t finalLength = endOfRowN - fromRowNOffset;

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1209,7 +1209,7 @@ ManagedString MicroBitLog::getNRows(uint32_t fromRowIndex, uint32_t nRows)
     //     end++;
     // }
 
-    startOfRowN = 8;
+    startOfRowN = dataStart + 8;
     const uint32_t dataLength = endOfDataChunk - startOfRowN;
     void *rowData = malloc(dataLength * sizeof(char*));
     cache.read(startOfRowN, rowData, endOfDataChunk);

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1217,15 +1217,15 @@ ManagedString MicroBitLog::getRows(uint32_t fromRowIndex, uint32_t nRows)
         end++;
     }
 
-    // const int dataLength = endOfDataChunk - startOfRowN;
-    // ManagedString rows(dataLength);
-    // cache.read(startOfRowN, (char *)(rows.toCharArray()), dataLength);
-    // return rows;
-
     const int dataLength = endOfDataChunk - startOfRowN;
-    void *rowData = malloc(dataLength * sizeof(char*));
-    cache.read(startOfRowN, rowData, dataLength);
-    return cleanBuffer((char*) rowData, dataLength);
+    ManagedString rows(dataLength);
+    cache.read(startOfRowN, (char *)(rows.toCharArray()), dataLength);
+    return rows;
+
+    // const int dataLength = endOfDataChunk - startOfRowN;
+    // void *rowData = malloc(dataLength * sizeof(char*));
+    // cache.read(startOfRowN, rowData, dataLength);
+    // return cleanBuffer((char*) rowData, dataLength);
 }
 
 /**

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1187,28 +1187,28 @@ ManagedString MicroBitLog::getNRows(uint32_t fromRowIndex, uint32_t nRows)
     uint32_t end = dataStart;
     uint32_t rowSeparatorCount = 0;
     uint8_t c = 0;
-    // while(c != 0xff)
-    // {
-    //     cache.read(end, &c, 1);
+    while(c != 0xff)
+    {
+        cache.read(end, &c, 1);
 
-    //     if (c == rowSeparator) {
-    //         rowSeparatorCount++;
-    //         if (!startRowFound && rowSeparatorCount == fromRowIndex) 
-    //         {
-    //             startRowFound = true;
-    //             startOfRowN = end;
-    //             break;
-    //         }
+        if (c == rowSeparator) {
+            rowSeparatorCount++;
+            if (!startRowFound && rowSeparatorCount == fromRowIndex) 
+            {
+                startRowFound = true;
+                startOfRowN = end;
+                break;
+            }
 
-    //         // else if (rowSeparatorCount == rowSeparatorTargetCount) 
-    //         // {
-    //         //     endOfDataChunk = end;
-    //         //     break;
-    //         // }
-    //     }
+            // else if (rowSeparatorCount == rowSeparatorTargetCount) 
+            // {
+            //     endOfDataChunk = end;
+            //     break;
+            // }
+        }
 
-    //     end++;
-    // }
+        end++;
+    }
 
     // startOfRowN = dataStart + 8;
     const int dataLength = endOfDataChunk - startOfRowN;

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1174,8 +1174,8 @@ ManagedString MicroBitLog::getNRows(uint32_t fromRowIndex, uint32_t nRows)
         return cleanBuffer("", 0);
     }
 
-    // constexpr uint8_t rowSeparator = 10; // newline char
-    constexpr uint8_t rowSeparator = 0x2C; // ','
+    constexpr uint8_t rowSeparator = 10; // newline char
+    // constexpr uint8_t rowSeparator = 0x2C; // ','
     const uint32_t rowSeparatorTargetCount = fromRowIndex + nRows + 1;
 
     uint8_t startOfRowN = dataStart;
@@ -1209,7 +1209,7 @@ ManagedString MicroBitLog::getNRows(uint32_t fromRowIndex, uint32_t nRows)
         end++;
     }
 
-    // startOfRowN = 10;
+    startOfRowN = 8;
     const uint32_t dataLength = endOfDataChunk - startOfRowN;
     void *rowData = malloc(dataLength * sizeof(char*));
     cache.read(startOfRowN, rowData, dataLength);

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1182,7 +1182,7 @@ ManagedString MicroBitLog::getNRows(uint32_t fromRowIndex, uint32_t nRows)
 
             if (!startFound && rowSeparatorQty == fromRowIndex) 
             {
-                startFound = true
+                startFound = true;
                 fromRowNOffset = i;
             }
 

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -24,7 +24,6 @@ DEALINGS IN THE SOFTWARE.
 
 #include "MicroBitLog.h"
 #include "CodalDmesg.h"
-#include <algorithm> // for std::min
 #include <new>
 #include <cstdio>
 
@@ -1141,7 +1140,9 @@ int MicroBitLog::_readSource( uint8_t *&data, uint32_t &index, uint32_t &len, ui
     return r;
 }
 
-
+/**
+* Get the number of rows (including the header) that exist in the datalog.
+*/
 uint32_t MicroBitLog::getNumberOfRows()
 {
     constexpr uint8_t rowSeparator = 10; // newline char
@@ -1168,24 +1169,23 @@ uint32_t MicroBitLog::getNumberOfRows()
  * Get n rows worth of logged data as a ManagedString
  * Each element is seperated by a newline
  */
-ManagedString MicroBitLog::getNRows(uint32_t fromRowIndex, uint32_t nRows)
+ManagedString MicroBitLog::getRows(uint32_t fromRowIndex, uint32_t nRows)
 {
-    if (fromRowIndex >= dataEnd || nRows == 0) {
+    if (fromRowIndex >= dataEnd || nRows == 0)
         return cleanBuffer("", 0);
-    }
 
     constexpr uint8_t rowSeparator = 10; // newline char in asci
     const uint32_t rowSeparatorTargetCount = fromRowIndex + nRows + 1;
 
     uint32_t startOfRowN = dataStart;
     uint32_t endOfDataChunk = dataEnd;
-
-    bool startRowFound = false;
-
-    // Read read until we see a 0xFF character (unused memory)
+    
     uint32_t end = dataStart;
     uint32_t rowSeparatorCount = 0;
+    bool startRowFound = false;
     uint8_t c = 0;
+
+    // Read read until we see a 0xFF character (unused memory)
     while(c != 0xff)
     {
         cache.read(end, &c, 1);

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1140,8 +1140,10 @@ int MicroBitLog::_readSource( uint8_t *&data, uint32_t &index, uint32_t &len, ui
     return r;
 }
 
+
 /**
 * Get the number of rows (including the header) that exist in the datalog.
+* @return number of rows + header
 */
 uint32_t MicroBitLog::getNumberOfRows()
 {
@@ -1166,9 +1168,11 @@ uint32_t MicroBitLog::getNumberOfRows()
 }
 
 /**
- * Get n rows worth of logged data as a ManagedString
- * Each element is seperated by a newline
- */
+* Get n rows worth of logged data as a ManagedString
+* @param fromRowIndex 0-based index of starting row
+* @param nRows number of rows to get from fromRowIndex
+* @return ManagedString of all data in these rows, each column separated by a '_'
+*/
 ManagedString MicroBitLog::getRows(uint32_t fromRowIndex, uint32_t nRows)
 {
     if (fromRowIndex >= dataEnd || nRows == 0)
@@ -1215,9 +1219,9 @@ ManagedString MicroBitLog::getRows(uint32_t fromRowIndex, uint32_t nRows)
 }
 
 /**
- * Get all the logged data as a ManagedString.
- * Each element is seperated by a _
- */
+* Get all the logged data as a ManagedString.
+* Each element is seperated by a '_'
+*/
 ManagedString MicroBitLog::getData() 
 {
     const int length = dataEnd - dataStart;

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1185,6 +1185,7 @@ ManagedString MicroBitLog::getRows(uint32_t fromRowIndex, int nRows)
 
     constexpr uint8_t rowSeparator = 10; // newline char in asci
     const uint32_t rowSeparatorTargetCount = fromRowIndex + nRows;
+    fromRowIndex++; // First rowSeparator found == first row (1 != 0) -> increment
 
     uint32_t startOfRowN = dataStart;
     uint32_t endOfDataChunk = dataEnd;

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1210,7 +1210,7 @@ ManagedString MicroBitLog::getNRows(uint32_t fromRowIndex, uint32_t nRows)
     // }
 
     // startOfRowN = dataStart + 8;
-    const uint32_t dataLength = endOfDataChunk - startOfRowN;
+    const int dataLength = endOfDataChunk - startOfRowN;
     void *rowData = malloc(dataLength * sizeof(char*));
     cache.read(startOfRowN, rowData, dataLength);
     return cleanBuffer((char*) rowData, dataLength);

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1142,7 +1142,6 @@ int MicroBitLog::_readSource( uint8_t *&data, uint32_t &index, uint32_t &len, ui
 }
 
 
-
 uint32_t MicroBitLog::getNumberOfRows()
 {
     constexpr uint8_t rowSeparator = 10; // newline char
@@ -1180,33 +1179,34 @@ ManagedString MicroBitLog::getNRows(uint32_t fromRowIndex, uint32_t nRows)
 
     uint8_t startOfRowN = dataStart + 1;
     uint8_t endOfDataChunk = logEnd;
-    uint32_t rowSeparatorIterator = 0;
 
     bool startRowFound = false;
 
     uint8_t d = 0;
     uint32_t i = dataStart + 1;
 
-    while(i < logEnd)
+    // Read read until we see a 0xFF character (unused memory)
+    uint32_t end = dataStart;
+    uint8_t c = 0;
+    while(c != 0xff)
     {
-        cache.read(i, &d, 1);
-        if (d == rowSeparator)
-        {
-            rowSeparatorIterator++;
+        cache.read(end, &c, 1);
 
-            if (!startRowFound && rowSeparatorIterator == fromRowIndex) 
+        if (c == rowSeparator) {
+            if (!startRowFound && end == fromRowIndex) 
             {
                 startRowFound = true;
-                startOfRowN = i;
+                startOfRowN = end;
             }
 
-            else if (rowSeparatorIterator == rowSeparatorTargetCount) 
+            else if (end == rowSeparatorTargetCount) 
             {
-                endOfDataChunk = i;
+                endOfDataChunk = end;
                 break;
             }
         }
-        i++;
+
+        end++;
     }
 
     const uint32_t dataLength = endOfDataChunk - startOfRowN;

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1218,9 +1218,11 @@ ManagedString MicroBitLog::getRows(uint32_t fromRowIndex, uint32_t nRows)
     }
 
     const int dataLength = endOfDataChunk - startOfRowN;
-    ManagedString rows("", dataLength);
-    cache.read(startOfRowN, (char *)(rows.toCharArray()), dataLength);
-    return rows;
+    char rows[dataLength];
+    cache.read(startOfRowN, rows, dataLength);
+    return ManagedString(rows, dataLength);
+
+    // cache.read(startOfRowN, (char *)(rows.toCharArray()), dataLength);
 
     // const int dataLength = endOfDataChunk - startOfRowN;
     // void *rowData = malloc(dataLength * sizeof(char*));

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1175,9 +1175,9 @@ ManagedString MicroBitLog::getNRows(uint32_t fromRowIndex, uint32_t nRows)
     }
 
     constexpr uint8_t rowSeparator = 10; // newline char
-    const uint32_t rowSeparatorTargetCount = fromRowIndex + nRows + 1;
+    const uint32_t rowSeparatorTargetCount = fromRowIndex + nRows;
 
-    uint8_t startOfRowN = dataStart + 1;
+    uint8_t startOfRowN = dataStart;
     uint8_t endOfDataChunk = logEnd;
 
     bool startRowFound = false;

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1170,16 +1170,16 @@ uint32_t MicroBitLog::getNumberOfRows()
  */
 ManagedString MicroBitLog::getNRows(uint32_t fromRowIndex, uint32_t nRows)
 {
-    // if (fromRowIndex >= dataEnd || nRows == 0) {
-    //     return cleanBuffer("", 0);
-    // }
+    if (fromRowIndex >= dataEnd || nRows == 0) {
+        return cleanBuffer("", 0);
+    }
 
     constexpr uint8_t rowSeparator = 10; // newline char
     // constexpr uint8_t rowSeparator = 0x2C; // ','
     const uint32_t rowSeparatorTargetCount = fromRowIndex + nRows + 1;
 
-    uint8_t startOfRowN = dataStart;
-    uint8_t endOfDataChunk = dataEnd;
+    uint32_t startOfRowN = dataStart;
+    uint32_t endOfDataChunk = dataEnd;
 
     bool startRowFound = false;
 

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1187,28 +1187,28 @@ ManagedString MicroBitLog::getNRows(uint32_t fromRowIndex, uint32_t nRows)
     uint32_t end = dataStart;
     uint32_t rowSeparatorCount = 0;
     uint8_t c = 0;
-    while(c != 0xff)
-    {
-        cache.read(end, &c, 1);
+    // while(c != 0xff)
+    // {
+    //     cache.read(end, &c, 1);
 
-        if (c == rowSeparator) {
-            rowSeparatorCount++;
-            if (!startRowFound && rowSeparatorCount == fromRowIndex) 
-            {
-                startRowFound = true;
-                startOfRowN = end;
-                break;
-            }
+    //     if (c == rowSeparator) {
+    //         rowSeparatorCount++;
+    //         if (!startRowFound && rowSeparatorCount == fromRowIndex) 
+    //         {
+    //             startRowFound = true;
+    //             startOfRowN = end;
+    //             break;
+    //         }
 
-            // else if (rowSeparatorCount == rowSeparatorTargetCount) 
-            // {
-            //     endOfDataChunk = end;
-            //     break;
-            // }
-        }
+    //         // else if (rowSeparatorCount == rowSeparatorTargetCount) 
+    //         // {
+    //         //     endOfDataChunk = end;
+    //         //     break;
+    //         // }
+    //     }
 
-        end++;
-    }
+    //     end++;
+    // }
 
     // startOfRowN = dataStart + 8;
     const int dataLength = endOfDataChunk - startOfRowN;

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1217,10 +1217,15 @@ ManagedString MicroBitLog::getRows(uint32_t fromRowIndex, uint32_t nRows)
         end++;
     }
 
+    // const int dataLength = endOfDataChunk - startOfRowN;
+    // ManagedString rows(dataLength);
+    // cache.read(startOfRowN, (char *)(rows.toCharArray()), dataLength);
+    // return rows;
+
     const int dataLength = endOfDataChunk - startOfRowN;
-    ManagedString rows(dataLength);
-    cache.read(startOfRowN, (char *)(rows.toCharArray()), dataLength);
-    return rows;
+    void *rowData = malloc(dataLength * sizeof(char*));
+    cache.read(startOfRowN, rowData, dataLength);
+    return cleanBuffer((char*) rowData, dataLength);
 }
 
 /**

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1149,7 +1149,7 @@ uint32_t MicroBitLog::getNumberOfRows()
     uint32_t rowCount = 0;
 
     // Read read until we see a 0xFF character (unused memory)
-    uint32_t end = start;
+    uint32_t end = dataStart;
     uint8_t c = 0;
     while(c != 0xff)
     {

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1217,9 +1217,9 @@ ManagedString MicroBitLog::getRows(uint32_t fromRowIndex, uint32_t nRows)
     }
 
     const int dataLength = endOfDataChunk - startOfRowN;
-    ManagedString rowData = ManagedString("", dataLength);
-    cache.read(startOfRowN, (char *)(rowData.toCharArray()), dataLength);
-    return rowData;
+    ManagedString rows = ManagedString("", dataLength);
+    cache.read(startOfRowN, (char *)(rows.toCharArray()), dataLength);
+    return rows;
 }
 
 /**

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1218,7 +1218,7 @@ ManagedString MicroBitLog::getRows(uint32_t fromRowIndex, uint32_t nRows)
     }
 
     const int dataLength = endOfDataChunk - startOfRowN;
-    ManagedString rows(dataLength);
+    ManagedString rows("", dataLength);
     cache.read(startOfRowN, (char *)(rows.toCharArray()), dataLength);
     return rows;
 

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1187,19 +1187,21 @@ ManagedString MicroBitLog::getNRows(uint32_t fromRowIndex, uint32_t nRows)
 
     // Read read until we see a 0xFF character (unused memory)
     uint32_t end = dataStart;
+    uint32_t rowSeparatorCount = 0;
     uint8_t c = 0;
     while(c != 0xff)
     {
         cache.read(end, &c, 1);
 
         if (c == rowSeparator) {
-            if (!startRowFound && end == fromRowIndex) 
+            rowSeparatorCount++;
+            if (!startRowFound && rowSeparatorCount == fromRowIndex) 
             {
                 startRowFound = true;
                 startOfRowN = end;
             }
 
-            else if (end == rowSeparatorTargetCount) 
+            else if (rowSeparatorCount == rowSeparatorTargetCount) 
             {
                 endOfDataChunk = end;
                 break;

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1208,7 +1208,7 @@ ManagedString MicroBitLog::getNRows(uint32_t fromRowIndex, uint32_t nRows)
         end++;
     }
 
-    const uint32_t dataLength = endOfDataChunk - dataStart;
+    const uint32_t dataLength = endOfDataChunk - startOfRowN;
     void *rowData = malloc(dataLength * sizeof(char*));
     cache.read(startOfRowN, rowData, dataLength);
     return cleanBuffer((char*) rowData, dataLength);

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1217,8 +1217,8 @@ ManagedString MicroBitLog::getRows(uint32_t fromRowIndex, uint32_t nRows)
     }
 
     const int dataLength = endOfDataChunk - startOfRowN;
-    ManagedBuffer rowData(dataLength);
-    cache.read(startOfRowN, rowData.toCharArray(), dataLength);
+    rowData = ManagedString(dataLength);
+    cache.read(startOfRowN, *(char *)(rowData.toCharArray()), dataLength);
     return rowData;
 }
 

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1154,39 +1154,32 @@ ManagedString MicroBitLog::getNRows(uint32_t fromRowIndex, uint32_t nRows)
         return cleanBuffer("", 0);
     }
 
-    // Number of columns ('_' separators) to find:
-    // constexpr uint32_t colQty = 4;
-    // constexpr uint8_t colSeparator = 95; // '_'
     constexpr uint8_t rowSeparator = 10; // newline char
-
-    // Number of columns expected before the start of the data
-    // const uint32_t colTargetStartQty = fromRowIndex * colQty;
-    // const uint32_t colTargetEndQty = colTargetStartQty + (nRows * colQty);
     const uint32_t rowTargetEndQty = fromRowIndex + nRows;
 
-    uint8_t fromRowNOffset = 0;
-    uint8_t endOfRowN = 0;
-    // uint32_t colSeparatorQty = 0;
-    uint32_t rowSeparatorQty = 0;
-    bool startFound = false;
+    uint8_t startOfRowN = dataStart + 1;
+    uint8_t endOfRowN = dataEnd;
+    uint32_t rowSeparatorIterator = 0;
+
+    bool startRowFound = false;
 
     uint8_t d = 0;
-    uint32_t i = dataStart;
+    uint32_t i = dataStart + 1;
 
     while(i < dataEnd)
     {
         cache.read(i, &d, 1);
         if (d == rowSeparator)
         {
-            rowSeparatorQty++;
+            rowSeparatorIterator++;
 
-            if (!startFound && rowSeparatorQty == fromRowIndex) 
+            if (!startRowFound && rowSeparatorIterator == fromRowIndex) 
             {
-                startFound = true;
-                fromRowNOffset = i;
+                startRowFound = true;
+                startOfRowN = i;
             }
 
-            else if (rowSeparatorQty == rowTargetEndQty) 
+            else if (rowSeparatorIterator == rowTargetEndQty) 
             {
                 endOfRowN = i;
                 break;
@@ -1196,10 +1189,10 @@ ManagedString MicroBitLog::getNRows(uint32_t fromRowIndex, uint32_t nRows)
         i++;
     }
 
-    const uint32_t finalLength = endOfRowN - fromRowNOffset;
-    void *rowData = malloc(finalLength * sizeof(char*));
-    cache.read(dataStart, rowData, finalLength);
-    return cleanBuffer((char*) rowData, finalLength);
+    const uint32_t dataLength = endOfRowN - startOfRowN;
+    void *rowData = malloc(dataLength * sizeof(char*));
+    cache.read(dataStart, rowData, dataLength);
+    return cleanBuffer((char*) rowData, dataLength);
 }
 
 /**

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1187,32 +1187,32 @@ ManagedString MicroBitLog::getNRows(uint32_t fromRowIndex, uint32_t nRows)
     uint32_t end = dataStart;
     uint32_t rowSeparatorCount = 0;
     uint8_t c = 0;
-    while(c != 0xff)
-    {
-        cache.read(end, &c, 1);
+    // while(c != 0xff)
+    // {
+    //     cache.read(end, &c, 1);
 
-        if (c == rowSeparator) {
-            rowSeparatorCount++;
-            if (!startRowFound && rowSeparatorCount == fromRowIndex) 
-            {
-                startRowFound = true;
-                startOfRowN = end;
-            }
+    //     if (c == rowSeparator) {
+    //         rowSeparatorCount++;
+    //         if (!startRowFound && rowSeparatorCount == fromRowIndex) 
+    //         {
+    //             startRowFound = true;
+    //             startOfRowN = end;
+    //         }
 
-            else if (rowSeparatorCount == rowSeparatorTargetCount) 
-            {
-                endOfDataChunk = end;
-                break;
-            }
-        }
+    //         else if (rowSeparatorCount == rowSeparatorTargetCount) 
+    //         {
+    //             endOfDataChunk = end;
+    //             break;
+    //         }
+    //     }
 
-        end++;
-    }
+    //     end++;
+    // }
 
     startOfRowN = 8;
     const uint32_t dataLength = endOfDataChunk - startOfRowN;
     void *rowData = malloc(dataLength * sizeof(char*));
-    cache.read(startOfRowN, rowData, dataLength);
+    cache.read(startOfRowN, rowData, endOfDataChunk);
     return cleanBuffer((char*) rowData, dataLength);
 }
 

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1218,7 +1218,7 @@ ManagedString MicroBitLog::getRows(uint32_t fromRowIndex, int nRows)
     }
 
     // fromRowIndex was beyond the datalogger:
-    if (!startFound)
+    if (!startRowFound)
         return ManagedString("", 0);
 
     const int dataLength = endOfDataChunk - startOfRowN;

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1153,7 +1153,7 @@ ManagedString MicroBitLog::getNRows(uint32_t fromRowIndex, uint32_t nRows)
     }
 
     constexpr uint8_t rowSeparator = 10; // newline char
-    const uint32_t rowSeparatorTargetCount = fromRowIndex + nRows + 3;
+    const uint32_t rowSeparatorTargetCount = fromRowIndex + nRows + 1;
 
     uint8_t startOfRowN = dataStart + 1;
     uint8_t endOfDataChunk = logEnd;

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1174,8 +1174,7 @@ ManagedString MicroBitLog::getNRows(uint32_t fromRowIndex, uint32_t nRows)
         return cleanBuffer("", 0);
     }
 
-    constexpr uint8_t rowSeparator = 10; // newline char
-    // constexpr uint8_t rowSeparator = 0x2C; // ','
+    constexpr uint8_t rowSeparator = 10; // newline char in asci
     const uint32_t rowSeparatorTargetCount = fromRowIndex + nRows + 1;
 
     uint32_t startOfRowN = dataStart;
@@ -1197,20 +1196,18 @@ ManagedString MicroBitLog::getNRows(uint32_t fromRowIndex, uint32_t nRows)
             {
                 startRowFound = true;
                 startOfRowN = end;
-                break;
             }
 
-            // else if (rowSeparatorCount == rowSeparatorTargetCount) 
-            // {
-            //     endOfDataChunk = end;
-            //     break;
-            // }
+            else if (rowSeparatorCount == rowSeparatorTargetCount) 
+            {
+                endOfDataChunk = end;
+                break;
+            }
         }
 
         end++;
     }
 
-    // startOfRowN = dataStart + 8;
     const int dataLength = endOfDataChunk - startOfRowN;
     void *rowData = malloc(dataLength * sizeof(char*));
     cache.read(startOfRowN, rowData, dataLength);

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1142,6 +1142,29 @@ int MicroBitLog::_readSource( uint8_t *&data, uint32_t &index, uint32_t &len, ui
 }
 
 
+
+uint32_t MicroBitLog::getNumberOfRows()
+{
+    constexpr uint8_t rowSeparator = 10; // newline char
+    uint32_t rowCount = 0;
+
+    // Read read until we see a 0xFF character (unused memory)
+    uint32_t end = start;
+    uint8_t c = 0;
+    while(c != 0xff)
+    {
+        cache.read(end, &c, 1);
+
+        if (c == rowSeparator) {
+            rowCount++;
+        }
+
+        end++;
+    }
+
+    return rowCount;
+}
+
 /**
  * Get n rows worth of logged data as a ManagedString
  * Each element is seperated by a newline

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1153,7 +1153,7 @@ ManagedString MicroBitLog::getNRows(uint32_t fromRowIndex, uint32_t nRows)
     }
 
     constexpr uint8_t rowSeparator = 10; // newline char
-    const uint32_t rowSeparatorTargetCount = fromRowIndex + nRows + 1;
+    const uint32_t rowSeparatorTargetCount = fromRowIndex + nRows + 3;
 
     uint8_t startOfRowN = dataStart + 1;
     uint8_t endOfDataChunk = logEnd;

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1179,7 +1179,7 @@ ManagedString MicroBitLog::getNRows(uint32_t fromRowIndex, uint32_t nRows)
     const uint32_t rowSeparatorTargetCount = fromRowIndex + nRows + 1;
 
     uint8_t startOfRowN = dataStart;
-    uint8_t endOfDataChunk = logEnd;
+    uint8_t endOfDataChunk = dataEnd;
 
     bool startRowFound = false;
 

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1217,6 +1217,10 @@ ManagedString MicroBitLog::getRows(uint32_t fromRowIndex, int nRows)
         end++;
     }
 
+    // fromRowIndex was beyond the datalogger:
+    if (!startFound)
+        return ManagedString("", 0);
+
     const int dataLength = endOfDataChunk - startOfRowN;
     char rows[dataLength];
     cache.read(startOfRowN, rows, dataLength);

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1170,12 +1170,12 @@ uint32_t MicroBitLog::getNumberOfRows()
  */
 ManagedString MicroBitLog::getNRows(uint32_t fromRowIndex, uint32_t nRows)
 {
-    if (fromRowIndex >= dataEnd) {
+    if (fromRowIndex >= dataEnd || nRows == 0) {
         return cleanBuffer("", 0);
     }
 
     constexpr uint8_t rowSeparator = 10; // newline char
-    const uint32_t rowSeparatorTargetCount = fromRowIndex + nRows;
+    const uint32_t rowSeparatorTargetCount = fromRowIndex + nRows + 1;
 
     uint8_t startOfRowN = dataStart;
     uint8_t endOfDataChunk = logEnd;
@@ -1195,7 +1195,7 @@ ManagedString MicroBitLog::getNRows(uint32_t fromRowIndex, uint32_t nRows)
             if (!startRowFound && rowSeparatorCount == fromRowIndex) 
             {
                 startRowFound = true;
-                startOfRowN = end;
+                startOfRowN = dataStart + end;
             }
 
             else if (rowSeparatorCount == rowSeparatorTargetCount) 

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1144,9 +1144,7 @@ int MicroBitLog::_readSource( uint8_t *&data, uint32_t &index, uint32_t &len, ui
 
 /**
  * Get n rows worth of logged data as a ManagedString
- * Each element is seperated by a _
- * Presumes 4 columns of data
- * This algorithm has optimisation potential
+ * Each element is seperated by a newline
  */
 ManagedString MicroBitLog::getNRows(uint32_t fromRowIndex, uint32_t nRows)
 {
@@ -1155,10 +1153,10 @@ ManagedString MicroBitLog::getNRows(uint32_t fromRowIndex, uint32_t nRows)
     }
 
     constexpr uint8_t rowSeparator = 10; // newline char
-    const uint32_t rowTargetEndQty = fromRowIndex + nRows;
+    const uint32_t rowTargetEndQty = fromRowIndex + nRows + 1;
 
     uint8_t startOfRowN = dataStart + 1;
-    uint8_t endOfRowN = dataEnd;
+    uint8_t endOfRowN = logEnd;
     uint32_t rowSeparatorIterator = 0;
 
     bool startRowFound = false;
@@ -1166,7 +1164,7 @@ ManagedString MicroBitLog::getNRows(uint32_t fromRowIndex, uint32_t nRows)
     uint8_t d = 0;
     uint32_t i = dataStart + 1;
 
-    while(i < dataEnd)
+    while(i < logEnd)
     {
         cache.read(i, &d, 1);
         if (d == rowSeparator)

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1195,7 +1195,7 @@ ManagedString MicroBitLog::getNRows(uint32_t fromRowIndex, uint32_t nRows)
             if (!startRowFound && rowSeparatorCount == fromRowIndex) 
             {
                 startRowFound = true;
-                startOfRowN = dataStart + end;
+                startOfRowN = end;
             }
 
             else if (rowSeparatorCount == rowSeparatorTargetCount) 
@@ -1210,7 +1210,7 @@ ManagedString MicroBitLog::getNRows(uint32_t fromRowIndex, uint32_t nRows)
 
     const uint32_t dataLength = endOfDataChunk - startOfRowN;
     void *rowData = malloc(dataLength * sizeof(char*));
-    cache.read(dataStart, rowData, dataLength);
+    cache.read(startOfRowN, rowData, dataLength);
     return cleanBuffer((char*) rowData, dataLength);
 }
 

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1170,9 +1170,9 @@ uint32_t MicroBitLog::getNumberOfRows()
  */
 ManagedString MicroBitLog::getNRows(uint32_t fromRowIndex, uint32_t nRows)
 {
-    if (fromRowIndex >= dataEnd || nRows == 0) {
-        return cleanBuffer("", 0);
-    }
+    // if (fromRowIndex >= dataEnd || nRows == 0) {
+    //     return cleanBuffer("", 0);
+    // }
 
     constexpr uint8_t rowSeparator = 10; // newline char
     // constexpr uint8_t rowSeparator = 0x2C; // ','

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1153,7 +1153,7 @@ ManagedString MicroBitLog::getNRows(uint32_t fromRowIndex, uint32_t nRows)
     }
 
     constexpr uint8_t rowSeparator = 10; // newline char
-    const uint32_t rowTargetEndQty = fromRowIndex + nRows + 1;
+    const uint32_t rowTargetEndQty = fromRowIndex + nRows + 2;
 
     uint8_t startOfRowN = dataStart + 1;
     uint8_t endOfRowN = logEnd;

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1212,7 +1212,7 @@ ManagedString MicroBitLog::getNRows(uint32_t fromRowIndex, uint32_t nRows)
     // startOfRowN = dataStart + 8;
     const uint32_t dataLength = endOfDataChunk - startOfRowN;
     void *rowData = malloc(dataLength * sizeof(char*));
-    cache.read(startOfRowN, rowData, endOfDataChunk);
+    cache.read(startOfRowN, rowData, dataLength);
     return cleanBuffer((char*) rowData, dataLength);
 }
 

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1185,14 +1185,13 @@ ManagedString MicroBitLog::getRows(uint32_t fromRowIndex, int nRows)
 
     constexpr uint8_t rowSeparator = 10; // newline char in asci
     const uint32_t rowSeparatorTargetCount = fromRowIndex + nRows;
-    fromRowIndex++; // First rowSeparator found == first row (1 != 0) -> increment
 
     uint32_t startOfRowN = dataStart;
     uint32_t endOfDataChunk = dataEnd;
     
     uint32_t end = dataStart;
     uint32_t rowSeparatorCount = 0;
-    bool startRowFound = false;
+    bool startRowFound = (fromRowIndex == 0) ? true : false;
     
     // Read until we see a 0xFF character (unused memory)
     uint8_t c = 0;

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1184,7 +1184,7 @@ ManagedString MicroBitLog::getRows(uint32_t fromRowIndex, uint32_t nRows)
         return ManagedString("", 0);
 
     constexpr uint8_t rowSeparator = 10; // newline char in asci
-    const uint32_t rowSeparatorTargetCount = fromRowIndex + nRows + 1;
+    const uint32_t rowSeparatorTargetCount = fromRowIndex + nRows;
 
     uint32_t startOfRowN = dataStart;
     uint32_t endOfDataChunk = dataEnd;
@@ -1221,13 +1221,6 @@ ManagedString MicroBitLog::getRows(uint32_t fromRowIndex, uint32_t nRows)
     char rows[dataLength];
     cache.read(startOfRowN, rows, dataLength);
     return ManagedString(rows, dataLength);
-
-    // cache.read(startOfRowN, (char *)(rows.toCharArray()), dataLength);
-
-    // const int dataLength = endOfDataChunk - startOfRowN;
-    // void *rowData = malloc(dataLength * sizeof(char*));
-    // cache.read(startOfRowN, rowData, dataLength);
-    // return cleanBuffer((char*) rowData, dataLength);
 }
 
 /**

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1195,7 +1195,7 @@ ManagedString MicroBitLog::getNRows(uint32_t fromRowIndex, uint32_t nRows)
             if (!startRowFound && rowSeparatorCount == fromRowIndex) 
             {
                 startRowFound = true;
-                startOfRowN = end;
+                startOfRowN = end + 1;
             }
 
             else if (rowSeparatorCount == rowSeparatorTargetCount) 

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1174,7 +1174,8 @@ ManagedString MicroBitLog::getNRows(uint32_t fromRowIndex, uint32_t nRows)
         return cleanBuffer("", 0);
     }
 
-    constexpr uint8_t rowSeparator = 10; // newline char
+    // constexpr uint8_t rowSeparator = 10; // newline char
+    constexpr uint8_t rowSeparator = 0x5F; // '_'
     const uint32_t rowSeparatorTargetCount = fromRowIndex + nRows + 1;
 
     uint8_t startOfRowN = dataStart;
@@ -1208,7 +1209,7 @@ ManagedString MicroBitLog::getNRows(uint32_t fromRowIndex, uint32_t nRows)
         end++;
     }
 
-    startOfRowN = 10;
+    // startOfRowN = 10;
     const uint32_t dataLength = endOfDataChunk - startOfRowN;
     void *rowData = malloc(dataLength * sizeof(char*));
     cache.read(startOfRowN, rowData, dataLength);

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1217,8 +1217,8 @@ ManagedString MicroBitLog::getRows(uint32_t fromRowIndex, uint32_t nRows)
     }
 
     const int dataLength = endOfDataChunk - startOfRowN;
-    ManagedString rows = ManagedString("", dataLength);
-    cache.read(startOfRowN, (char *)(rows.toCharArray()), dataLength);
+    rows = ManagedString("", dataLength);
+    // cache.read(startOfRowN, (char *)(rows.toCharArray()), dataLength);
     return rows;
 }
 

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1187,9 +1187,9 @@ ManagedString MicroBitLog::getRows(uint32_t fromRowIndex, uint32_t nRows)
     uint32_t end = dataStart;
     uint32_t rowSeparatorCount = 0;
     bool startRowFound = false;
-    uint8_t c = 0;
-
+    
     // Read read until we see a 0xFF character (unused memory)
+    uint8_t c = 0;
     while(c != 0xff)
     {
         cache.read(end, &c, 1);
@@ -1217,19 +1217,6 @@ ManagedString MicroBitLog::getRows(uint32_t fromRowIndex, uint32_t nRows)
     cache.read(startOfRowN, rowData, dataLength);
     return cleanBuffer((char*) rowData, dataLength);
 }
-
-/**
-* Get all the logged data as a ManagedString.
-* Each element is seperated by a '_'
-*/
-ManagedString MicroBitLog::getData() 
-{
-    const int length = dataEnd - dataStart;
-    void *rowData = malloc(length * sizeof(char*));
-    cache.read(dataStart, rowData, length);
-    return cleanBuffer((char*) rowData, length);
-}
-
 
 /**
  * Destructor.

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1195,12 +1195,12 @@ ManagedString MicroBitLog::getNRows(uint32_t fromRowIndex, uint32_t nRows)
             if (!startRowFound && rowSeparatorCount == fromRowIndex) 
             {
                 startRowFound = true;
-                startOfRowN = rowSeparatorCount;
+                startOfRowN = end;
             }
 
             else if (rowSeparatorCount == rowSeparatorTargetCount) 
             {
-                endOfDataChunk = rowSeparatorCount;
+                endOfDataChunk = end;
                 break;
             }
         }

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1208,6 +1208,7 @@ ManagedString MicroBitLog::getNRows(uint32_t fromRowIndex, uint32_t nRows)
         end++;
     }
 
+    startOfRowN = 10;
     const uint32_t dataLength = endOfDataChunk - startOfRowN;
     void *rowData = malloc(dataLength * sizeof(char*));
     cache.read(startOfRowN, rowData, dataLength);

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1143,22 +1143,28 @@ int MicroBitLog::_readSource( uint8_t *&data, uint32_t &index, uint32_t &len, ui
 
 /**
 * Get the number of rows (including the header) that exist in the datalog.
+* @param fromRowIndex 0-based index of starting row
 * @return number of rows + header
 */
-uint32_t MicroBitLog::getNumberOfRows()
+uint32_t MicroBitLog::getNumberOfRows(uint32_t fromRowIndex)
 {
     constexpr uint8_t rowSeparator = 10; // newline char
     uint32_t rowCount = 0;
 
-    // Read read until we see a 0xFF character (unused memory)
     uint32_t end = dataStart;
+    bool startFound = false;
+
+    // Read read until we see a 0xFF character (unused memory)
     uint8_t c = 0;
     while(c != 0xff)
     {
         cache.read(end, &c, 1);
-
         if (c == rowSeparator) {
             rowCount++;
+            if (!startFound && fromRowIndex == rowCount) {
+                startFound = true;
+                rowCount = 0;
+            }
         }
 
         end++;
@@ -1188,7 +1194,7 @@ ManagedString MicroBitLog::getRows(uint32_t fromRowIndex, uint32_t nRows)
     uint32_t rowSeparatorCount = 0;
     bool startRowFound = false;
     
-    // Read read until we see a 0xFF character (unused memory)
+    // Read until we see a 0xFF character (unused memory)
     uint8_t c = 0;
     while(c != 0xff)
     {

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1182,9 +1182,6 @@ ManagedString MicroBitLog::getNRows(uint32_t fromRowIndex, uint32_t nRows)
 
     bool startRowFound = false;
 
-    uint8_t d = 0;
-    uint32_t i = dataStart + 1;
-
     // Read read until we see a 0xFF character (unused memory)
     uint32_t end = dataStart;
     uint32_t rowSeparatorCount = 0;
@@ -1198,12 +1195,12 @@ ManagedString MicroBitLog::getNRows(uint32_t fromRowIndex, uint32_t nRows)
             if (!startRowFound && rowSeparatorCount == fromRowIndex) 
             {
                 startRowFound = true;
-                startOfRowN = end;
+                startOfRowN = rowSeparatorCount;
             }
 
             else if (rowSeparatorCount == rowSeparatorTargetCount) 
             {
-                endOfDataChunk = end;
+                endOfDataChunk = rowSeparatorCount;
                 break;
             }
         }

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1209,7 +1209,7 @@ ManagedString MicroBitLog::getNRows(uint32_t fromRowIndex, uint32_t nRows)
     //     end++;
     // }
 
-    startOfRowN = dataStart + 8;
+    // startOfRowN = dataStart + 8;
     const uint32_t dataLength = endOfDataChunk - startOfRowN;
     void *rowData = malloc(dataLength * sizeof(char*));
     cache.read(startOfRowN, rowData, endOfDataChunk);

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1153,10 +1153,10 @@ ManagedString MicroBitLog::getNRows(uint32_t fromRowIndex, uint32_t nRows)
     }
 
     constexpr uint8_t rowSeparator = 10; // newline char
-    const uint32_t rowTargetEndQty = fromRowIndex + nRows + 2;
+    const uint32_t rowSeparatorTargetCount = fromRowIndex + nRows + 1;
 
     uint8_t startOfRowN = dataStart + 1;
-    uint8_t endOfRowN = logEnd;
+    uint8_t endOfDataChunk = logEnd;
     uint32_t rowSeparatorIterator = 0;
 
     bool startRowFound = false;
@@ -1177,17 +1177,16 @@ ManagedString MicroBitLog::getNRows(uint32_t fromRowIndex, uint32_t nRows)
                 startOfRowN = i;
             }
 
-            else if (rowSeparatorIterator == rowTargetEndQty) 
+            else if (rowSeparatorIterator == rowSeparatorTargetCount) 
             {
-                endOfRowN = i;
+                endOfDataChunk = i;
                 break;
             }
         }
-
         i++;
     }
 
-    const uint32_t dataLength = endOfRowN - startOfRowN;
+    const uint32_t dataLength = endOfDataChunk - startOfRowN;
     void *rowData = malloc(dataLength * sizeof(char*));
     cache.read(dataStart, rowData, dataLength);
     return cleanBuffer((char*) rowData, dataLength);

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1217,8 +1217,8 @@ ManagedString MicroBitLog::getRows(uint32_t fromRowIndex, uint32_t nRows)
     }
 
     const int dataLength = endOfDataChunk - startOfRowN;
-    rowData = ManagedString(dataLength);
-    cache.read(startOfRowN, *(char *)(rowData.toCharArray()), dataLength);
+    rowData = ManagedString("", dataLength);
+    cache.read(startOfRowN, (char *)(rowData.toCharArray()), dataLength);
     return rowData;
 }
 

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1175,7 +1175,7 @@ ManagedString MicroBitLog::getNRows(uint32_t fromRowIndex, uint32_t nRows)
     }
 
     // constexpr uint8_t rowSeparator = 10; // newline char
-    constexpr uint8_t rowSeparator = 0x5F; // '_'
+    constexpr uint8_t rowSeparator = 0x2C; // ','
     const uint32_t rowSeparatorTargetCount = fromRowIndex + nRows + 1;
 
     uint8_t startOfRowN = dataStart;

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1216,7 +1216,6 @@ ManagedString MicroBitLog::getNRows(uint32_t fromRowIndex, uint32_t nRows)
 
             if (!startFound && colSeparatorQty == colTargetStartQty) 
             {
-                foundAllRows = startFound;
                 fromRowNOffset = start;
             }
 

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1217,7 +1217,7 @@ ManagedString MicroBitLog::getRows(uint32_t fromRowIndex, uint32_t nRows)
     }
 
     const int dataLength = endOfDataChunk - startOfRowN;
-    rows = ManagedString("", dataLength);
+    ManagedString rows(dataLength);
     // cache.read(startOfRowN, (char *)(rows.toCharArray()), dataLength);
     return rows;
 }

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1178,7 +1178,7 @@ uint32_t MicroBitLog::getNumberOfRows(uint32_t fromRowIndex)
 * @param nRows number of rows to get from fromRowIndex
 * @return ManagedString of all data in these rows, each column separated by a newline
 */
-ManagedString MicroBitLog::getRows(uint32_t fromRowIndex, uint32_t nRows)
+ManagedString MicroBitLog::getRows(uint32_t fromRowIndex, int nRows)
 {
     if (fromRowIndex >= dataEnd || nRows <= 0)
         return ManagedString("", 0);

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -24,6 +24,7 @@ DEALINGS IN THE SOFTWARE.
 
 #include "MicroBitLog.h"
 #include "CodalDmesg.h"
+#include <new>
 
 #define ARRAY_LEN(array)    (sizeof(array) / sizeof(array[0]))
 
@@ -1180,7 +1181,7 @@ uint32_t MicroBitLog::getNumberOfRows(uint32_t fromRowIndex)
 ManagedString MicroBitLog::getRows(uint32_t fromRowIndex, uint32_t nRows)
 {
     if (fromRowIndex >= dataEnd || nRows <= 0)
-        return cleanBuffer("", 0);
+        return ManagedString("", 0);
 
     constexpr uint8_t rowSeparator = 10; // newline char in asci
     const uint32_t rowSeparatorTargetCount = fromRowIndex + nRows + 1;
@@ -1216,15 +1217,10 @@ ManagedString MicroBitLog::getRows(uint32_t fromRowIndex, uint32_t nRows)
         end++;
     }
 
-    // const int dataLength = endOfDataChunk - startOfRowN;
-    // ManagedString rows(dataLength);
-    // // cache.read(startOfRowN, (char *)(rows.toCharArray()), dataLength);
-    // return rows;
-
     const int dataLength = endOfDataChunk - startOfRowN;
-    void *rowData = malloc(dataLength * sizeof(char*));
-    cache.read(startOfRowN, rowData, dataLength);
-    return cleanBuffer((char*) rowData, dataLength);
+    ManagedString rows(dataLength);
+    cache.read(startOfRowN, (char *)(rows.toCharArray()), dataLength);
+    return rows;
 }
 
 /**

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1217,7 +1217,7 @@ ManagedString MicroBitLog::getRows(uint32_t fromRowIndex, uint32_t nRows)
     }
 
     const int dataLength = endOfDataChunk - startOfRowN;
-    rowData = ManagedString("", dataLength);
+    ManagedString rowData = ManagedString("", dataLength);
     cache.read(startOfRowN, (char *)(rowData.toCharArray()), dataLength);
     return rowData;
 }

--- a/source/MicroBitLog.cpp
+++ b/source/MicroBitLog.cpp
@@ -1176,7 +1176,7 @@ uint32_t MicroBitLog::getNumberOfRows(uint32_t fromRowIndex)
 * Get n rows worth of logged data as a ManagedString
 * @param fromRowIndex 0-based index of starting row
 * @param nRows number of rows to get from fromRowIndex
-* @return ManagedString of all data in these rows, each column separated by a newline
+* @return ManagedString between the parameter range, each row separated by a newline, each column by a comma
 */
 ManagedString MicroBitLog::getRows(uint32_t fromRowIndex, int nRows)
 {


### PR DESCRIPTION
I have added two new functions to \source\MicroBitLog.cpp & \inc\MicroBitLog.h

These two functions allow for the access of the contents of the datalogger in a relatively abstract manner. They mean that a user can read back data from the datalogger directly from the microbit - without needing to upload the MY_DATA.HTM file. This is useful for building more complex microbit applications - such as with MicroData: https://github.com/KierPalin/MicroData - which is an application that uses the Microbit and an ArcadeShield to help teach data & physical sciences. In the case of MicroData the user can record data using the Microbit's onboard & Jacdac sensors, and then read that data back in a tabular or graphical format on the ArcadeShield's screen - without the need of a PC. I believe there are many other cases where the ability to read back rows of data or the number of rows may be useful though.


I have verified the proper functionality of these two new functions via 10 tests that can be found here: https://github.com/KierPalin/MicroData/blob/codal_testing/tests.ts