### PR TITLE
Addition of getRows(n, k) and getNumberOfRows(n) to the datalogger. 

### DIFF
--- a/inc/MicroBitLog.h
+++ b/inc/MicroBitLog.h
@@ -361,6 +361,21 @@ namespace codal
          */
         int readData(void *data, uint32_t index, uint32_t len, DataFormat format, uint32_t length);
 
+        /**
+        * Get the number of rows (including the header) in the datalogger.
+        * @param fromRowIndex 0-based index of starting row: bumped up to 0 if negative.
+        * @return number of rows + header.
+        */
+        uint32_t getNumberOfRows(uint32_t fromRowIndex = 0);
+
+        /**
+        * Get n rows worth of logged data as a ManagedString.
+        * @param fromRowIndex 0-based index of starting row.
+        * @param nRows number of rows to get from fromRowIndex.
+        * @return ManagedString between the parameter range, each row separated by a newline, each column by a comma.
+        */
+        ManagedString getRows(uint32_t fromRowIndex, int nRows);
+
     private:
 
         /**


### PR DESCRIPTION
I have added two new functions to \source\MicroBitLog.cpp & \inc\MicroBitLog.h

These two functions allow for the access of the contents of the datalogger in a relatively abstract manner. They mean that a user can read back data from the datalogger directly from the microbit - without needing to upload the MY_DATA.HTM file. This is useful for building more complex microbit applications - such as with MicroData: https://github.com/KierPalin/MicroData - which is an application that uses the Microbit and an ArcadeShield to help teach data & physical sciences. In the case of MicroData the user can record data using the Microbit's onboard & Jacdac sensors, and then read that data back in a tabular or graphical format on the ArcadeShield's screen - without the need of a PC. I believe there are many other cases where the ability to read back rows of data or the number of rows may be useful though.

I have verified the proper functionality of these two new functions via 10 tests that can be found here: 
https://github.com/KierPalin/MicroData/blob/codal_testing/tests.ts


Pertinent edge-cases:
getNumberOfRows(n) where n is greater than number of rows in the datalogger -> 0
getNumberOfRows(n) where n is negative -> n becomes 0

1) getRows(n, k) where n is negative ->  empty string
2) getRows(n, k) where k is 0 or negative -> empty string
3) getRows(n, k) where n is greater than number of rows in the datalogger (start row is never reached) -> empty string
4) getRows(n, k) where k is greater than number of rows in the datalogger -> All rows from n 
                 (case 3 takes precedence from case 4 if n is too great)

getRows(n, k) when new columns are added after logging rows -> Returns rows normally, then a row with all of the columns (new and old), then the rows of data again. This is true even when adding more columns, then more columns again. For example:

Input:
Add 5 rows of data.
Add additional column
Add another additional column
Output:
1 row of the headers used by the original data
5 rows of data
1 row of headers - including the additional column
1 row of headers - including both of the additional columns




