### PR TITLE
Populate `MICROBIT_DAL_VERSION` and add `microbit_dal_version()`.

### DIFF
--- a/inc/MicroBitConfig.h
+++ b/inc/MicroBitConfig.h
@@ -283,12 +283,15 @@
 #endif
 
 // Versioning options.
-// We use semantic versioning (http://semver.org/) to identify differnet versions of the micro:bit runtime.
-// Where possible we use yotta (an ARM mbed build tool) to help us track versions.
-// if this isn't available, it can be defined manually as a configuration option.
+// We use semantic versioning (http://semver.org/) to identify different versions of the micro:bit runtime.
+// If this isn't available, it can be defined manually as a configuration option.
 //
 #ifndef MICROBIT_DAL_VERSION
-    #define MICROBIT_DAL_VERSION                    "unknown"
+    #ifdef DEVICE_DAL_VERSION
+        #define MICROBIT_DAL_VERSION                DEVICE_DAL_VERSION
+    #else
+        #define MICROBIT_DAL_VERSION                "unknown"
+    #endif
 #endif
 
 // Allow USB serial events to wake the board from deep sleep.

--- a/inc/MicroBitDevice.h
+++ b/inc/MicroBitDevice.h
@@ -96,7 +96,7 @@ namespace codal
     void microbit_reset();
 
     /**
-     * Determine the version of microbit-dal currently running.
+     * For DAL compatibility, determine the version of DAL/CODAL currently running.
      * @return a pointer to a character buffer containing a representation of the semantic version number.
      */
     const char * microbit_dal_version();

--- a/source/MicroBitDevice.cpp
+++ b/source/MicroBitDevice.cpp
@@ -193,6 +193,15 @@ __NO_RETURN void microbit_reset()
 }
 
 /**
+  * For DAL compatibility, determine the version of DAL/CODAL currently running.
+  * @return a pointer to a character buffer containing a representation of the semantic version number.
+  */
+const char * microbit_dal_version()
+{
+    return MICROBIT_DAL_VERSION;
+}
+
+/**
   * Seed the random number generator (RNG).
   *
   * This function uses the NRF52833's in built cryptographic random number generator to seed a Galois LFSR.

--- a/target-locked.json
+++ b/target-locked.json
@@ -50,7 +50,7 @@
     "generate_hex": true,
     "libraries": [
         {
-            "branch": "992c0b11a0eb2a1edca9c2f76821f89a99a3acec",
+            "branch": "c46d62943bc05a1b8296663ac4c643475a3e8a4c",
             "name": "codal-core",
             "type": "git",
             "url": "https://github.com/lancaster-university/codal-core"


### PR DESCRIPTION
This PR required the latest commit from codal-core from PR:
- https://github.com/lancaster-university/codal-core/pull/169

And with these two PRs we can get the following defines and function outputs:

```
CODAL_VERSION_MAJOR: 0
CODAL_VERSION_MINOR: 2
CODAL_VERSION_PATCH: 66
CODAL_VERSION_HASH: 8c8db00
CODAL_TARGET_NAME: codal-microbit-v2
CODAL_VERSION: 0.2.66
CODAL_VERSION_LONG: 0.2.66+codal-microbit-v2-8c8db00
DEVICE_DAL_VERSION: 0.2.66
MICROBIT_DAL_VERSION: 0.2.66
microbit_dal_version(): 0.2.66
uBit.getVersion(): 0.2.66
```