### PR TITLE
Allow log full FUL to be written to last byte

### DIFF
--- a/source/FSCache.cpp
+++ b/source/FSCache.cpp
@@ -84,7 +84,7 @@ int FSCache::read(uint32_t address, const void *data, int len)
 	int bytesCopied = 0;
 
 	// Ensure that the operation is within the limits of the device
-	if (address < flash.getFlashStart() || address + len >= flash.getFlashEnd())
+	if (address < flash.getFlashStart() || address + len > flash.getFlashEnd())
 		return DEVICE_INVALID_PARAMETER;
 
 	// Read operation may span multiple cache boundaries... so we iterate over blocks as necessary.
@@ -116,7 +116,7 @@ int FSCache::write(uint32_t address, const void *data, int len)
 	int bytesCopied = 0;
 
 	// Ensure that the operation is within the limits of the device
-	if (address < flash.getFlashStart() || address + len >= flash.getFlashEnd())
+	if (address < flash.getFlashStart() || address + len > flash.getFlashEnd())
 		return DEVICE_INVALID_PARAMETER;
 
 #ifdef CODAL_FS_CACHE_VALIDATE


### PR DESCRIPTION
Fixes https://github.com/lancaster-university/codal-microbit-v2/issues/406

With this program, FUL is in the HTM file, and LOG FULL appears, only after this change. 
```
#include "MicroBit.h"

MicroBit uBit;

int main() {
    uBit.init();

    uBit.display.print("?");

    while (true) {
        uBit.log.logString("1234567890,1234567890,1234567890,1234567890,1234567890\n");
        uBit.sleep(1);

        if (uBit.log.isFull()) {
            uBit.display.print("D");
            uBit.sleep(100);
        }
    }
}
```

![image](https://github.com/user-attachments/assets/f322580f-e9ed-4378-a632-674e540035a6)



![image](https://github.com/user-attachments/assets/ff695eb2-e08d-447c-a9e4-b98b3a4f2eec)

