### PR TITLE
Temporarily set CODAL_VERSION back to "unknown".

### DIFF
--- a/target-locked.json
+++ b/target-locked.json
@@ -11,6 +11,7 @@
         "CODAL_PROVIDE_PRINTF": 1,
         "CODAL_TIMER_32BIT": 1,
         "CODAL_TIMESTAMP": "uint64_t",
+        "CODAL_VERSION": "\"unknown\"",
         "CONFIG_GPIO_AS_PINRESET": 1,
         "CONFIG_NFCT_PINS_AS_GPIOS": 1,
         "DEVICE_BLE": 1,

--- a/target.json
+++ b/target.json
@@ -7,7 +7,6 @@
     "generate_bin":true,
     "generate_hex":true,
     "config":{
-
         "MBED_CONF_NORDIC_NRF_LF_CLOCK_SRC": "NRF_LF_SRC_XTAL",
         "CONFIG_GPIO_AS_PINRESET": 1,
         "CONFIG_NFCT_PINS_AS_GPIOS": 1,
@@ -42,7 +41,8 @@
         "CAPTOUCH_DEFAULT_CALIBRATION" : 3500,
         "HARDWARE_NEOPIXEL": 1,
         "CODAL_TIMER_32BIT": 1,
-        "DEVICE_BLE": 1
+        "DEVICE_BLE": 1,
+        "CODAL_VERSION": "unknown"
     },
     "definitions":"-DAPP_TIMER_V2 -DAPP_TIMER_V2_RTC1_ENABLED -DNRF_DFU_TRANSPORT_BLE=1 -DNRF52833_XXAA -DNRF52833 -DTARGET_MCU_NRF52833 -DNRF5 -DNRF52833 -D__CORTEX_M4 -DS113 -DTOOLCHAIN_GCC -D__START=target_start",
 


### PR DESCRIPTION
This is to workaround an issue in the iOS app as described in:
- https://github.com/microsoft/pxt-microbit/issues/5913

Versions with this patch:

```
CODAL_VERSION_MAJOR: 0
CODAL_VERSION_MINOR: 2
CODAL_VERSION_PATCH: 67
CODAL_VERSION_HASH: a8470a7
CODAL_TARGET_NAME: codal-microbit-v2
CODAL_VERSION: unknown
CODAL_VERSION_LONG: unknown+codal-microbit-v2-a8470a7
DEVICE_DAL_VERSION: unknown
MICROBIT_DAL_VERSION: unknown
microbit_dal_version(): unknown
uBit.getVersion(): unknown
```