### PR TITLE
Ensure float operations in `SoundSynthesizerEffects` & `CompassCalibrator`.

### DIFF
--- a/source/MicroBitCompassCalibrator.cpp
+++ b/source/MicroBitCompassCalibrator.cpp
@@ -168,7 +168,7 @@ CompassCalibration MicroBitCompassCalibrator::spherify(Sample3D centre, Sample3D
 
     for (int i = 0; i < samples; i++)
     {
-        int d = sqrt((float)centre.dSquared(data[i]));
+        int d = sqrtf((float)centre.dSquared(data[i]));
 
         if (d > radius)
             radius = d;
@@ -179,7 +179,7 @@ CompassCalibration MicroBitCompassCalibrator::spherify(Sample3D centre, Sample3D
     for (int i = 0; i < samples; i++)
     {
         // Calculate the distance from this point to the centre of the sphere
-        float d = sqrt(centre.dSquared(data[i]));
+        float d = sqrtf(centre.dSquared(data[i]));
 
         // Now determine a scalar multiplier that, when applied to the vector to the centre,
         // will place this point on the surface of the sphere.
@@ -198,11 +198,11 @@ CompassCalibration MicroBitCompassCalibrator::spherify(Sample3D centre, Sample3D
         weightZ += s * fabsf(dz / d);
     }
 
-    float wmag = sqrt((weightX * weightX) + (weightY * weightY) + (weightZ * weightZ));
+    float wmag = sqrtf((weightX * weightX) + (weightY * weightY) + (weightZ * weightZ));
 
-    scaleX = 1.0 + scale * (weightX / wmag);
-    scaleY = 1.0 + scale * (weightY / wmag);
-    scaleZ = 1.0 + scale * (weightZ / wmag);
+    scaleX = 1.0f + scale * (weightX / wmag);
+    scaleY = 1.0f + scale * (weightY / wmag);
+    scaleZ = 1.0f + scale * (weightZ / wmag);
 
     result.scale.x = (int)(1024 * scaleX);
     result.scale.y = (int)(1024 * scaleY);

--- a/source/SoundExpressions.cpp
+++ b/source/SoundExpressions.cpp
@@ -276,8 +276,8 @@ bool SoundExpressions::parseSoundExpression(const char *soundChars, SoundEffect 
     }
 
     // Volume envelope
-    float effectVolumeFloat = (float) CLAMP(0, effectVolume, 1023) / 1023.0;
-    float endVolumeFloat = (float) CLAMP(0, endVolume, 1023) / 1023.0;
+    float effectVolumeFloat = (float) CLAMP(0, effectVolume, 1023) / 1023.0f;
+    float endVolumeFloat = (float) CLAMP(0, endVolume, 1023) / 1023.0f;
     fx->volume = volumeScaleFactor * effectVolumeFloat;
     fx->effects[1].effect = SoundSynthesizerEffects::volumeRampEffect;
     fx->effects[1].steps = 36;

--- a/source/SoundSynthesizerEffects.cpp
+++ b/source/SoundSynthesizerEffects.cpp
@@ -102,11 +102,11 @@ void SoundSynthesizerEffects::linearInterpolation(SoundEmojiSynthesizer *synth, 
 void SoundSynthesizerEffects::logarithmicInterpolation(SoundEmojiSynthesizer *synth, ToneEffect *context)
 {
     // Original frequency gen here, for reference. -John
-    //synth->frequency = synth->effect->frequency+(log10(context->step)*(context->parameter[0]-synth->effect->frequency)/1.95);
+    //synth->frequency = synth->effect->frequency+(log10f(context->step)*(context->parameter[0]-synth->effect->frequency)/1.95);
 
-    synth->frequency = synth->effect->frequency+(log10(
+    synth->frequency = synth->effect->frequency+(log10f(
         ( context->step==0 ? 1 : context->step )                 // This is a hack, to prevent step==0 from jumping this to extreme values. -John
-    )*(context->parameter[0]-synth->effect->frequency)/1.95);
+    )*(context->parameter[0]-synth->effect->frequency)/1.95f);
 
     // This is a bit of a hack, but will protect the synth for now until the math here can be fixed properly. -John
     if( synth->frequency < 0 )
@@ -117,39 +117,39 @@ void SoundSynthesizerEffects::logarithmicInterpolation(SoundEmojiSynthesizer *sy
 // parameter[0]: end frequency
 void SoundSynthesizerEffects::curveInterpolation(SoundEmojiSynthesizer *synth, ToneEffect *context)
 {
-    synth->frequency = (sin(context->step*3.14159f/180.0f)*(context->parameter[0]-synth->effect->frequency)+synth->effect->frequency);
+    synth->frequency = (sinf(context->step*3.14159f/180.0f)*(context->parameter[0]-synth->effect->frequency)+synth->effect->frequency);
 }
 
 // Cosine interpolate function
 // parameter[0]: end frequency
 void SoundSynthesizerEffects::slowVibratoInterpolation(SoundEmojiSynthesizer *synth, ToneEffect *context){
-    synth->frequency = sin(context->step/10)*context->parameter[0]+synth->effect->frequency;
+    synth->frequency = sinf(context->step/10)*context->parameter[0]+synth->effect->frequency;
 }
 
 //warble function
 // parameter[0]: end frequency
 void SoundSynthesizerEffects::warbleInterpolation(SoundEmojiSynthesizer *synth, ToneEffect *context)
 {
-    synth->frequency = (sin(context->step)*(context->parameter[0]-synth->effect->frequency)+synth->effect->frequency);
+    synth->frequency = (sinf(context->step)*(context->parameter[0]-synth->effect->frequency)+synth->effect->frequency);
 }
 
 // Vibrato function
 // parameter[0]: end frequency
 void SoundSynthesizerEffects::vibratoInterpolation(SoundEmojiSynthesizer *synth, ToneEffect *context){
-    synth->frequency = synth->effect->frequency + sin(context->step)*context->parameter[0];
+    synth->frequency = synth->effect->frequency + sinf(context->step)*context->parameter[0];
 }
 
 // Exponential rising function
 // parameter[0]: end frequency
 void SoundSynthesizerEffects::exponentialRisingInterpolation(SoundEmojiSynthesizer *synth, ToneEffect *context)
 {
-    synth->frequency = synth->effect->frequency + sin(0.01745329f*context->step)*context->parameter[0];
+    synth->frequency = synth->effect->frequency + sinf(0.01745329f*context->step)*context->parameter[0];
 }
 
 // Exponential falling function
 void SoundSynthesizerEffects::exponentialFallingInterpolation(SoundEmojiSynthesizer *synth, ToneEffect *context)
 {
-    synth->frequency = synth->effect->frequency + cos(0.01745329f*context->step)*context->parameter[0];
+    synth->frequency = synth->effect->frequency + cosf(0.01745329f*context->step)*context->parameter[0];
 }
 
 // Argeppio functions


### PR DESCRIPTION
Related PR, which includes files in codal-core like `LevelDetectorSPL`, and together with this PR it saves >400 bytes of flash:
- https://github.com/lancaster-university/codal-core/pull/176

_Edit: Also ensured float literals in a couple of other files to avoid implicit double promotion._