### PR TITLE
Fix Pi value typo.

### DIFF
--- a/source/SoundSynthesizerEffects.cpp
+++ b/source/SoundSynthesizerEffects.cpp
@@ -117,7 +117,7 @@ void SoundSynthesizerEffects::logarithmicInterpolation(SoundEmojiSynthesizer *sy
 // parameter[0]: end frequency
 void SoundSynthesizerEffects::curveInterpolation(SoundEmojiSynthesizer *synth, ToneEffect *context)
 {
-    synth->frequency = (sin(context->step*3.12159f/180.0f)*(context->parameter[0]-synth->effect->frequency)+synth->effect->frequency);
+    synth->frequency = (sin(context->step*3.14159f/180.0f)*(context->parameter[0]-synth->effect->frequency)+synth->effect->frequency);
 }
 
 // Cosine interpolate function


### PR DESCRIPTION
I assume this was a simple typo, but since it didn't use the `PI` macro either, I just wanted to double check in case it wasn't @finneyj.