### PR TITLE
CI: Reduce the min GCC version used to match what MakeCode (PXT) uses.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, macos-13, windows-2019]
-        gcc: ['7-2017-q4', 'latest']
+        gcc: ['6-2016-q4', 'latest']  # Min version 6.2 as used in pext/yotta:latest docker image
         cmake: ['3.6.0', '']  # Empty string installs the latest CMake release
       fail-fast: false
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
MakeCode builds use an older GCC version, so we need to make sure any changes remain compatible.

```
$ docker run --rm -it pext/yotta:latest arm-none-eabi-gcc --version
arm-none-eabi-gcc (GNU Tools for ARM Embedded Processors) 6.2.1 20161205 (release) [ARM/embedded-6-branch revision 243739]
Copyright (C) 2016 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```