### PR TITLE
eliminate compiler warnings

### DIFF
--- a/inc/MicroBitDevice.h
+++ b/inc/MicroBitDevice.h
@@ -110,7 +110,7 @@ namespace codal
      * microbit_panic(20);
      * @endcode
      */
-    void microbit_panic(int statusCode);
+    [[noreturn]] void microbit_panic(int statusCode);
 
     /**
      * Defines the length of time that the device will remain in a error state before resetting.

--- a/target-locked.json
+++ b/target-locked.json
@@ -1,7 +1,7 @@
 {
     "architecture": "CORTEX_M4F",
     "asm_flags": "-fno-exceptions -fno-unwind-tables --specs=nosys.specs -mcpu=cortex-m4 -mthumb",
-    "c_flags": "-std=c99 --specs=nosys.specs -Warray-bounds",
+    "c_flags": "-std=c99 --specs=nosys.specs -Warray-bounds --param=min-pagesize=0",
     "cmake_definitions": {
         "MBED_LEGACY_TOOLCHAIN": "GCC_ARM;"
     },

--- a/target-locked.json
+++ b/target-locked.json
@@ -1,7 +1,7 @@
 {
     "architecture": "CORTEX_M4F",
     "asm_flags": "-fno-exceptions -fno-unwind-tables --specs=nosys.specs -mcpu=cortex-m4 -mthumb",
-    "c_flags": "-std=c99 --specs=nosys.specs -Warray-bounds --param=min-pagesize=0",
+    "c_flags": "-std=c99 --specs=nosys.specs -Warray-bounds",
     "cmake_definitions": {
         "MBED_LEGACY_TOOLCHAIN": "GCC_ARM;"
     },


### PR DESCRIPTION
Adds noreturn attribute to microbit_panic(), to prevent gcc warning about missing returns in various functions that use panic.

Adds "--param=min-pagesize=0" to gcc compiler flags, to prevent gcc warning about dereferencing hardcoded pointers near address 0.