### PR TITLE
ci: Also build MakeCode & MicroPython on PRs.

### DIFF
--- a/.github/workflows/makecode.yml
+++ b/.github/workflows/makecode.yml
@@ -1,9 +1,9 @@
 name: Build MakeCode
 
-# MakeCode has to git clone/checkout this repo commit SHA, so only run this
-# workflow on pushes, as PRs generate a "merge commit" that is not clonable.
 on:
   push:
+    branches: '*'
+  pull_request:
     branches: '*'
 
 jobs:
@@ -50,6 +50,20 @@ jobs:
         run: |
           npm install -g pxt
           npm install
+      # MakeCode has to git clone/checkout this repo commit SHA, the GITHUB_SHA env
+      # variable from a PR represents the "merge commit" of that PR against main,
+      # and so that commit is not reachable by MakeCode because it's not pushed anywhere
+      - name: Set CODAL_MICROBIT_V2_SHA
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            CODAL_MICROBIT_V2_SHA=$(jq -r .pull_request.head.sha < $GITHUB_EVENT_PATH)
+          else
+            CODAL_MICROBIT_V2_SHA=${GITHUB_SHA}
+          fi
+          echo "CODAL_MICROBIT_V2_SHA=$CODAL_MICROBIT_V2_SHA" >> $GITHUB_ENV
+          echo "CODAL_MICROBIT_V2_SHA=$CODAL_MICROBIT_V2_SHA"
+        env:
+          GITHUB_EVENT_PATH: ${{ github.event_path }}
       - name: Edit pxtarget.json to use this repository and commit
         shell: bash
         run: |
@@ -79,7 +93,7 @@ jobs:
               mbcodal['compileService']['codalTarget']['url'] = mbcodal['compileService']['codalTarget']['url'].replace(
                   'lancaster-university/codal-microbit-v2', '${GITHUB_REPOSITORY}'
               )
-              mbcodal['compileService']['codalTarget']['branch'] = '${GITHUB_SHA}'
+              mbcodal['compileService']['codalTarget']['branch'] = '${{ env.CODAL_MICROBIT_V2_SHA }}'
 
           with open('pxtarget.json', 'w') as f:
               f.write(json.dumps(pxt_target, indent=4))

--- a/.github/workflows/micropython.yml
+++ b/.github/workflows/micropython.yml
@@ -1,9 +1,9 @@
 name: Build MicroPython
 
-# MicroPython has to git clone/checkout this repo commit SHA, so only run this
-# workflow on pushes, as PRs generate a "merge commit" that is not clonable.
 on:
   push:
+    branches: '*'
+  pull_request:
     branches: '*'
 
 jobs:
@@ -16,6 +16,12 @@ jobs:
         with:
           repository: 'microbit-foundation/micropython-microbit-v2'
           submodules: 'true'
+      - name: Manually clone microbit-v2-samples in the lib/codal/libraries folder
+        uses: actions/checkout@v4
+        with:
+          path: lib/codal/libraries/codal-microbit-v2
+          fetch-depth: '0'
+          submodules: 'recursive'
       - name: Setup arm-none-eabi-gcc v10.3
         uses: carlosperate/arm-none-eabi-gcc-action@v1
         with:


### PR DESCRIPTION
The main issue we had before is that on PRs GitHub creates a merge commit of the PR branch merged into main, and that git commit is not really pushed anywhere. So, when MicroPython and MakeCode try to git clone codal-microbit-v2 they get a git sha that does not exit in the upstream repo.

In MicroPython this is solved by using the action/checkout into the MicroPython codal/libraries folder.
In MakeCode it is solved by checking if the workflow is run from a PR, and in that case it just clones the PR branch, not the merge commit. That does mean that the MakeCode workflow does not run the test in the merge commit, but at least we'll have the results from the submitter's branch state. 