### PR TITLE
PWM2_IRQn (neopixel) priority increase for Bug fixes for rare glitches on WS2812B pixels (NeoPixels) and 030 errors on micro:bit V2 (3/3)

### DIFF
--- a/target-locked.json
+++ b/target-locked.json
@@ -53,16 +53,16 @@
     "generate_hex": true,
     "libraries": [
         {
-            "branch": "kjwpwmfix",
+            "branch": "8c8366f9a1e92da69f90fe816456c4b9c42ffd13",
             "name": "codal-core",
             "type": "git",
-            "url": "https://github.com/kevinjwalters/codal-core"
+            "url": "https://github.com/lancaster-university/codal-core"
         },
         {
-            "branch": "kjwpwmfix",
+            "branch": "1fbb7240290fe36a55c61378f5cdeb7640f3ec4a",
             "name": "codal-nrf52",
             "type": "git",
-            "url": "https://github.com/kevinjwalters/codal-nrf52"
+            "url": "https://github.com/lancaster-university/codal-nrf52"
         },
         {
             "branch": "4b8abc690f6c9fca6132e6db5ee13a795a263f88",

--- a/target.json
+++ b/target.json
@@ -60,14 +60,14 @@
     "libraries":[
         {
             "name":"codal-core",
-            "url":"https://github.com/kevinjwalters/codal-core",
-            "branch":"kjwpwmfix",
+            "url":"https://github.com/lancaster-university/codal-core",
+            "branch":"master",
             "type":"git"
         },
         {
             "name":"codal-nrf52",
-            "url":"https://github.com/kevinjwalters/codal-nrf52",
-            "branch":"kjwpwmfix",
+            "url":"https://github.com/lancaster-university/codal-nrf52",
+            "branch":"master",
             "type":"git"
         },
         {


### PR DESCRIPTION
This is a small change in terms of code with interrupt priority increase by a numerical decrease from 3 to 2 for `PWM2_IRQn` used for the code under the `neopixel` library. This could have large implications for MicroPython so is worthy of a thorough review by someone with substanital knowledge of the internals including CODAL.

---

Partner PRs:

 - https://github.com/lancaster-university/codal-nrf52/pull/61
 - https://github.com/lancaster-university/codal-core/pull/184
