### PR TITLE
feat: Optimize LED matrix driver for low CPU usage

### DIFF
--- a/inc/NRF52LedMatrix.h
+++ b/inc/NRF52LedMatrix.h
@@ -63,6 +63,16 @@ namespace codal
         
         int8_t              gpiote[NRF52_LED_MATRIX_MAXIMUM_COLUMNS];            // GPIOTE channels used by output columns.
         int8_t              ppi[NRF52_LED_MATRIX_MAXIMUM_COLUMNS];               // PPI channels used by output columns.
+        bool                is_dirty_;
+        uint32_t            image_checksum_;
+        bool                display_active_;
+        uint32_t            rendered_image_[5][NRF52_LED_MATRIX_MAXIMUM_COLUMNS];
+
+        private:
+        /**
+         * Calculates a checksum of the image buffer.
+         */
+        uint32_t calculate_checksum();
 
         public:
         /**


### PR DESCRIPTION
Implements a caching strategy to significantly reduce CPU usage during display refresh.

- A pre-rendered image buffer is used to store the computed timer values for the current display content.
- Expensive image processing is now only performed when the display content changes (detected by a checksum) or properties like brightness and rotation are modified (detected by a dirty flag).
- The high-frequency refresh operation now only involves copying the pre-computed values to the hardware, resulting in minimal CPU overhead.
- The display timer is now completely disabled when the screen is cleared, further reducing power consumption.