### PR TITLE
The build was failing because the compiler could not find NRF52Dma.h,…

### DIFF
--- a/module.json
+++ b/module.json
@@ -13,7 +13,8 @@
     "inc/",
     "inc/bluetooth/",
     "inc/compat/",
-    "model/"
+    "model/",
+    "../codal-nrf52/inc"
   ],
   "scripts": {
   }


### PR DESCRIPTION
… which is required by NRF52DmaLedMatrix.cpp.

This change adds the necessary include path to module.json to allow the compiler to find the header file in the codal-nrf52 dependency.