### PR TITLE
MicroBitDisplay: move display refresh timer ownership to MicroBit

### DIFF
--- a/inc/MicroBitDisplay.h
+++ b/inc/MicroBitDisplay.h
@@ -30,6 +30,7 @@ DEALINGS IN THE SOFTWARE.
 #include "codal-core/inc/types/Event.h"
 #include "NRF52LedMatrix.h"
 #include "AnimatedDisplay.h"
+#include "NRFLowLevelTimer.h"
 
 namespace codal
 {
@@ -49,8 +50,23 @@ namespace codal
          * @param map The mapping information that relates pin inputs/outputs to physical screen coordinates.
          * @param id The id the display should use when sending events on the MessageBus. Defaults to DEVICE_ID_DISPLAY.
          *
+         * @note This constructor is deprecated. Please use MicroBitDisplay(NRFLowLevelTimer&, const MatrixMap, uint16_t), which provides better handling of the timer used to update the display.
          */
+        [[deprecated("Replaced by MicroBitDisplay(NRFLowLevelTimer&, const MatrixMap, uint16_t), which provides better handling of the timer used to update the display.")]]
         MicroBitDisplay(const MatrixMap &map, uint16_t id = DEVICE_ID_DISPLAY);
+
+        /**
+         * Constructor.
+         *
+         * Create a software representation of the micro:bit's 5x5 LED matrix.
+         * The display is initially blank.
+         *
+         * @param t The timer to be used for display refresh.
+         * @param map The mapping information that relates pin inputs/outputs to physical screen coordinates.
+         * @param id The id the display should use when sending events on the MessageBus. Defaults to DEVICE_ID_DISPLAY.
+         *
+         */
+        MicroBitDisplay(NRFLowLevelTimer& t, const MatrixMap &map, uint16_t id = DEVICE_ID_DISPLAY);
 
         /**
          * Destructor.

--- a/model/MicroBit.cpp
+++ b/model/MicroBit.cpp
@@ -62,9 +62,10 @@ MicroBit::MicroBit() :
 
     systemTimer(NRF_TIMER1, TIMER1_IRQn),
     adcTimer(NRF_TIMER2, TIMER2_IRQn),
-
     capTouchTimer(NRF_TIMER3, TIMER3_IRQn),
+    displayTimer(NRF_TIMER4, TIMER4_IRQn),
     timer(systemTimer),
+	
     messageBus(),
     adc(adcTimer, 91),
     touchSensor(capTouchTimer),
@@ -79,7 +80,7 @@ MicroBit::MicroBit() :
     ledRowPins{&io.row1, &io.row2, &io.row3, &io.row4, &io.row5},
     ledColPins{&io.col1, &io.col2, &io.col3, &io.col4, &io.col5},
     ledMatrixMap{ 5, 5, 5, 5, (Pin**)ledRowPins, (Pin**)ledColPins, ledMatrixPositions},
-    display(ledMatrixMap),
+    display(displayTimer, ledMatrixMap),
     buttonA(io.P5, DEVICE_ID_BUTTON_A, DEVICE_BUTTON_ALL_EVENTS, ACTIVE_LOW, PullMode::None),
     buttonB(io.P11, DEVICE_ID_BUTTON_B, DEVICE_BUTTON_ALL_EVENTS, ACTIVE_LOW, PullMode::None),
     buttonAB(DEVICE_ID_BUTTON_A, DEVICE_ID_BUTTON_B, DEVICE_ID_BUTTON_AB),

--- a/model/MicroBit.h
+++ b/model/MicroBit.h
@@ -141,7 +141,9 @@ namespace codal
             NRFLowLevelTimer            systemTimer;
             NRFLowLevelTimer            adcTimer;
             NRFLowLevelTimer            capTouchTimer;
+            NRFLowLevelTimer            displayTimer;
             Timer                       timer;
+			
             MessageBus                  messageBus;
             NRF52ADC                    adc;
             NRF52TouchSensor            touchSensor;

--- a/source/MicroBitDisplay.cpp
+++ b/source/MicroBitDisplay.cpp
@@ -27,7 +27,6 @@ DEALINGS IN THE SOFTWARE.
  * Class definition for MicroBitDisplay
  */
 #include "MicroBitDisplay.h"
-#include "NRFLowLevelTimer.h"
 
 using namespace codal;
 
@@ -39,8 +38,25 @@ using namespace codal;
   *
   * @param map The mapping information that relates pin inputs/outputs to physical screen coordinates.
   * @param id The id the display should use when sending events on the MessageBus. Defaults to DEVICE_ID_DISPLAY.
+  *
+  * @note This constructor is deprecated. Please use MicroBitDisplay(NRFLowLevelTimer&, const MatrixMap, uint16_t), which provides better handling of the timer used to update the display.
   */
+[[deprecated("Replaced by MicroBitDisplay(NRFLowLevelTimer&, const MatrixMap, uint16_t), which provides better handling of the timer used to update the display.")]]
 MicroBitDisplay::MicroBitDisplay(const MatrixMap &map, uint16_t id) : NRF52LEDMatrix(*new NRFLowLevelTimer(NRF_TIMER4, TIMER4_IRQn), map, id, DisplayMode::DISPLAY_MODE_GREYSCALE), AnimatedDisplay(*this, id)
+{
+}
+
+/**
+  * Constructor.
+  *
+  * Create a software representation of the micro:bit's 5x5 LED matrix.
+  * The display is initially blank.
+  *
+  * @param t The timer to be used for display refresh.
+  * @param map The mapping information that relates pin inputs/outputs to physical screen coordinates.
+  * @param id The id the display should use when sending events on the MessageBus. Defaults to DEVICE_ID_DISPLAY.
+  */
+MicroBitDisplay::MicroBitDisplay(NRFLowLevelTimer& t, const MatrixMap &map, uint16_t id) : NRF52LEDMatrix(t, map, id, DisplayMode::DISPLAY_MODE_GREYSCALE), AnimatedDisplay(*this, id)
 {
 }
 


### PR DESCRIPTION
# Summary
This pull request updates how the display refresh timer is instantiated and owned within the Codal display stack. Instead of allocating the timer inline inside the `MicroBitDisplay` constructor, the timer is now created in `MicroBit` and passed into `MicroBitDisplay` by reference, aligning it with how other Codal timers (system, adc, touch) are managed.

# Motivation
Previously, `MicroBitDisplay` allocated the display refresh timer using `new` within its constructor. The resulting reference was not retained by `MicroBitDisplay` itself, relying instead on internal storage within `NRF52LedMatrix`. Since that member is private, the timer could not be explicitly managed or cleaned up. Also, `NRF52LedMatrix` does not allocate the timer, so it should not be responsible for maintaining it.
In rare (more advanced) scenarios, this could lead to orphaned timers and memory leaks.

# Implementation details
- The display refresh timer is now instantiated in `MicroBit`, similar to all other timers used by Codal.
- `MicroBitDisplay` receives the timer via reference, making ownership and lifetime explicit.
- The existing `MicroBitDisplay` constructor is preserved for compatibility but is marked as deprecated to discourage further use.
- No functional behaviour of the display refresh logic is changed.