### PR TITLE
linker: define __StackSize symbol, add .stack NOLOAD section

### DIFF
--- a/ld/nrf52832.ld
+++ b/ld/nrf52832.ld
@@ -145,6 +145,8 @@ SECTIONS
 
     __edata = .;
 
+    __StackSize = 0x800;    /* DEVICE_STACK_SIZE = 2048 */
+
     .noinit :
     {
       PROVIDE(__start_noinit = .);
@@ -169,8 +171,8 @@ SECTIONS
         *(.heap*);
 
         /* Expand the heap to reach the stack boundary. */
-        ASSERT(. <= (ORIGIN(RAM) + LENGTH(RAM) - 0x800), "heap region overflowed into stack");
-        . += (ORIGIN(RAM) + LENGTH(RAM) - 0x800) - .;
+        ASSERT(. <= (ORIGIN(RAM) + LENGTH(RAM) - __StackSize), "heap region overflowed into stack");
+        . += (ORIGIN(RAM) + LENGTH(RAM) - __StackSize) - .;
     } > RAM
     PROVIDE(__heap_start = ADDR(.heap));
     PROVIDE(__heap_size = SIZEOF(.heap));

--- a/ld/nrf52833-softdevice.ld
+++ b/ld/nrf52833-softdevice.ld
@@ -169,6 +169,9 @@ SECTIONS
         __data_end__ = .;
     } > RAM
     __edata = .;
+
+    __StackSize = 0x800;    /* DEVICE_STACK_SIZE = 2048 */
+
     .bss :
     {
         . = ALIGN(4);
@@ -183,10 +186,19 @@ SECTIONS
         __end__ = .;
         end = __end__;
         *(.heap*);
-        ASSERT(. <= (ORIGIN(RAM) + LENGTH(RAM) - 0x800), "heap region overflowed into stack");
-        . += (ORIGIN(RAM) + LENGTH(RAM) - 0x800) - .;
+        ASSERT(. <= (ORIGIN(RAM) + LENGTH(RAM) - __StackSize), "heap region overflowed into stack");
+        . += (ORIGIN(RAM) + LENGTH(RAM) - __StackSize) - .;
     } > RAM
+
+    .stack (NOLOAD):
+    {
+        . += __StackSize;
+    } > RAM
+
     __StackTop = ORIGIN(RAM) + LENGTH(RAM);
+    __StackLimit = ORIGIN(RAM) + LENGTH(RAM) - __StackSize;
     PROVIDE(__stack = __StackTop);
+
+    /DISCARD/ : { *(.stack*) }
 }
 

--- a/ld/nrf52833.ld
+++ b/ld/nrf52833.ld
@@ -142,6 +142,9 @@ SECTIONS
         __data_end__ = .;
     } > RAM
     __edata = .;
+
+    __StackSize = 0x800;    /* DEVICE_STACK_SIZE = 2048 */
+
     .bss :
     {
         . = ALIGN(4);
@@ -156,10 +159,19 @@ SECTIONS
         __end__ = .;
         end = __end__;
         *(.heap*);
-        ASSERT(. <= (ORIGIN(RAM) + LENGTH(RAM) - 0x800), "heap region overflowed into stack");
-        . += (ORIGIN(RAM) + LENGTH(RAM) - 0x800) - .;
+        ASSERT(. <= (ORIGIN(RAM) + LENGTH(RAM) - __StackSize), "heap region overflowed into stack");
+        . += (ORIGIN(RAM) + LENGTH(RAM) - __StackSize) - .;
     } > RAM
+
+    .stack (NOLOAD):
+    {
+        . += __StackSize;
+    } > RAM
+
     __StackTop = ORIGIN(RAM) + LENGTH(RAM);
+    __StackLimit = ORIGIN(RAM) + LENGTH(RAM) - __StackSize;
     PROVIDE(__stack = __StackTop);
+
+    /DISCARD/ : { *(.stack*) }
 }
 


### PR DESCRIPTION
context: running Lua on the microbit, and avoiding confusion WRT lua heap size vs microbit address space usage.

---

The ultimate reason for this change is that all of RAM is accounted for, so that at the end of the build we get 100% instead of the confusing:

  RAM:      129008 B     131056 B     98.44%

Replace the magic literal 0x800 (DEVICE_STACK_SIZE) with a named __stack_size symbol in all three linker scripts (nrf52833.ld, nrf52833-softdevice.ld, nrf52832.ld). This makes the stack reservation self-documenting and allows it to be referenced by name.

Add an explicit .stack (NOLOAD) section to nrf52833.ld and nrf52833-softdevice.ld so the linker accounts for the reserved stack region in its RAM usage report instead of leaving it as unaccounted space between .heap and __StackTop.