### PR TITLE
BLE: report pc/info and flush the DMESG buffer in the SD fault handler

### DIFF
--- a/source/bluetooth/MicroBitBLEManager.cpp
+++ b/source/bluetooth/MicroBitBLEManager.cpp
@@ -71,6 +71,7 @@ DEALINGS IN THE SOFTWARE.
 #include "MicroBitPartialFlashingService.h"
 
 #include "CodalDmesg.h"
+#include "codal_target_hal.h"
 #include "nrf_log_backend_dmesg.h"
 
 using namespace codal;
@@ -1589,16 +1590,23 @@ static void microbit_dfu_evt_handler(ble_dfu_buttonless_evt_type_t event)
 
 void app_error_fault_handler(uint32_t id, uint32_t pc, uint32_t info)
 {
+    // We may be running in the SD fault context at a priority above the UARTE IRQ,
+    // so the interrupt-driven serial TX cannot make progress. Switch to the robust
+    // polled path so this dump prints at full speed.
+    target_disable_irq();
+
     NRF_LOG_FINAL_FLUSH();
 
 #if (DEVICE_DMESG_BUFFER_SIZE > 0)
+    codal_dmesg_flush();
+
     switch (id)
     {
         case NRF_FAULT_ID_SD_ASSERT:
-            DMESG("SOFTDEVICE: ASSERTION FAILED");
+            DMESGF("SOFTDEVICE: ASSERTION FAILED pc=%x info=%x", pc, info);
             break;
         case NRF_FAULT_ID_APP_MEMACC:
-            DMESG("SOFTDEVICE: INVALID MEMORY ACCESS");
+            DMESGF("SOFTDEVICE: INVALID MEMORY ACCESS pc=%x info=%x", pc, info);
             break;
         case NRF_FAULT_ID_SDK_ASSERT:
         {
@@ -1638,7 +1646,7 @@ void app_error_fault_handler(uint32_t id, uint32_t pc, uint32_t info)
         }
     }
 
-    //DMESGF(""); // Uncomment to flush these DMESGs before the panic
+    codal_dmesg_flush();
 #endif // (DEVICE_DMESG_BUFFER_SIZE > 0)
 
     int panic;


### PR DESCRIPTION
this was needed to debug the 070 panic: https://github.com/lancaster-university/codal-microbit-v2/issues/506

maybe this depends on https://github.com/lancaster-university/codal-nrf52/pull/64

LLM slop, but looks plausible. it requires review nevertheless by someone who understands the codebase.

---

The fault handler is entered from the SoftDevice fault context, which runs at a priority above the UARTE IRQ. Mask IRQs so the interrupt-driven serial TX is replaced by the robust polled path, then flush the DMESG buffer so the full panic dump is emitted before the panic handler resets the device.

Also include the offending pc and info in the SD assert/memory-access messages, which are essential for diagnosing SoftDevice assertions such as the micro:bit v2 '070' radio-arming deadline violation.